### PR TITLE
feat: update agents to APS v1.1.11 conformance

### DIFF
--- a/.github/agents/excali.agent.md
+++ b/.github/agents/excali.agent.md
@@ -1,21 +1,24 @@
 ---
+name: excali
 description: Generate Excalidraw diagrams from text descriptions, wireframes, or specifications
 tools:
   - search/codebase
+  - search/fileSearch
   - read/readFile
   - edit/createFile
   - edit/createDirectory
-  - search/fileSearch
+user-invokable: true
+disable-model-invocation: false
+target: vscode
 ---
 
 <instructions>
-You are an expert at creating Excalidraw diagrams from text descriptions.
-You MUST output valid Excalidraw JSON that opens correctly in VS Code's Excalidraw extension.
+You MUST generate valid Excalidraw JSON that opens correctly in VS Code's Excalidraw extension.
 You MUST use unique IDs for each element and ensure bound elements reference valid IDs.
 You MUST calculate positions and sizes to create visually balanced layouts.
 You MUST use the exact property names and value formats specified in the constants.
-When creating connected diagrams, you MUST use arrows with proper startBinding/endBinding references.
-When adding text to shapes, you MUST use boundElements on the shape and containerId on the text.
+You MUST use arrows with proper startBinding/endBinding references when creating connected diagrams.
+You MUST use boundElements on the shape and containerId on the text when adding text to shapes.
 </instructions>
 
 <constants>
@@ -36,7 +39,6 @@ EXCALIDRAW_TEMPLATE: JSON<<
 >>
 
 ELEMENT_TYPES: TEXT<<
-
 - rectangle: boxes, containers, cards, panels
 - ellipse: circles, ovals, nodes
 - diamond: decision points, conditions
@@ -45,174 +47,168 @@ ELEMENT_TYPES: TEXT<<
 - text: labels, descriptions, standalone text
 - freedraw: hand-drawn sketches (rarely used programmatically)
 - image: embedded images (requires files object)
-  > >
+>>
 
 FILL_STYLES: TEXT<<
-
 - solid: uniform color fill
 - hachure: diagonal line pattern (hand-drawn look)
 - cross-hatch: crossed diagonal lines
 - transparent: no fill (default for shapes without backgroundColor)
-  > >
+>>
 
 STROKE_STYLES: TEXT<<
-
 - solid: continuous line (default)
 - dashed: long dashes
 - dotted: dots
-  > >
+>>
 
 COLOR_PALETTE: JSON<<
 {
-"stroke": {
-"black": "#1e1e1e",
-"gray": "#868e96",
-"red": "#e03131",
-"pink": "#c2255c",
-"grape": "#9c36b5",
-"violet": "#6741d9",
-"indigo": "#3b5bdb",
-"blue": "#1971c2",
-"cyan": "#0c8599",
-"teal": "#099268",
-"green": "#2f9e44",
-"lime": "#66a80f",
-"yellow": "#f08c00",
-"orange": "#e8590c"
-},
-"background": {
-"transparent": "transparent",
-"lightGray": "#f8f9fa",
-"gray": "#e9ecef",
-"darkGray": "#dee2e6",
-"red": "#ffc9c9",
-"pink": "#fcc2d7",
-"grape": "#eebefa",
-"violet": "#d0bfff",
-"indigo": "#bac8ff",
-"blue": "#a5d8ff",
-"cyan": "#99e9f2",
-"teal": "#96f2d7",
-"green": "#b2f2bb",
-"lime": "#d8f5a2",
-"yellow": "#fff3bf",
-"orange": "#ffd8a8"
+  "background": {
+    "blue": "#a5d8ff",
+    "cyan": "#99e9f2",
+    "darkGray": "#dee2e6",
+    "grape": "#eebefa",
+    "gray": "#e9ecef",
+    "green": "#b2f2bb",
+    "indigo": "#bac8ff",
+    "lightGray": "#f8f9fa",
+    "lime": "#d8f5a2",
+    "orange": "#ffd8a8",
+    "pink": "#fcc2d7",
+    "red": "#ffc9c9",
+    "teal": "#96f2d7",
+    "transparent": "transparent",
+    "violet": "#d0bfff",
+    "yellow": "#fff3bf"
+  },
+  "stroke": {
+    "black": "#1e1e1e",
+    "blue": "#1971c2",
+    "cyan": "#0c8599",
+    "grape": "#9c36b5",
+    "gray": "#868e96",
+    "green": "#2f9e44",
+    "indigo": "#3b5bdb",
+    "lime": "#66a80f",
+    "orange": "#e8590c",
+    "pink": "#c2255c",
+    "red": "#e03131",
+    "teal": "#099268",
+    "violet": "#6741d9",
+    "yellow": "#f08c00"
+  }
 }
-}
-
-> >
+>>
 
 RECTANGLE_TEMPLATE: JSON<<
 {
-"id": "UNIQUE_ID",
-"type": "rectangle",
-"x": 0,
-"y": 0,
-"width": 200,
-"height": 100,
-"angle": 0,
-"strokeColor": "#1e1e1e",
-"backgroundColor": "transparent",
-"fillStyle": "solid",
-"strokeWidth": 2,
-"strokeStyle": "solid",
-"roughness": 1,
-"opacity": 100,
-"groupIds": [],
-"frameId": null,
-"index": "a0",
-"roundness": { "type": 3 },
-"seed": 1000,
-"version": 1,
-"versionNonce": 1000,
-"isDeleted": false,
-"boundElements": null,
-"updated": 1700000000000,
-"link": null,
-"locked": false
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "fillStyle": "solid",
+  "frameId": null,
+  "groupIds": [],
+  "height": 100,
+  "id": "UNIQUE_ID",
+  "index": "a0",
+  "isDeleted": false,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "roughness": 1,
+  "roundness": {"type": 3},
+  "seed": 1000,
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "rectangle",
+  "updated": 1700000000000,
+  "version": 1,
+  "versionNonce": 1000,
+  "width": 200,
+  "x": 0,
+  "y": 0
 }
-
-> >
+>>
 
 TEXT_TEMPLATE: JSON<<
 {
-"id": "UNIQUE_ID",
-"type": "text",
-"x": 0,
-"y": 0,
-"width": 100,
-"height": 25,
-"angle": 0,
-"strokeColor": "#1e1e1e",
-"backgroundColor": "transparent",
-"fillStyle": "solid",
-"strokeWidth": 2,
-"strokeStyle": "solid",
-"roughness": 1,
-"opacity": 100,
-"groupIds": [],
-"frameId": null,
-"index": "a1",
-"roundness": null,
-"seed": 1001,
-"version": 1,
-"versionNonce": 1001,
-"isDeleted": false,
-"boundElements": null,
-"updated": 1700000000000,
-"link": null,
-"locked": false,
-"text": "Label",
-"fontSize": 20,
-"fontFamily": 5,
-"textAlign": "center",
-"verticalAlign": "middle",
-"containerId": null,
-"originalText": "Label",
-"autoResize": true,
-"lineHeight": 1.25
+  "angle": 0,
+  "autoResize": true,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "containerId": null,
+  "fillStyle": "solid",
+  "fontFamily": 5,
+  "fontSize": 20,
+  "frameId": null,
+  "groupIds": [],
+  "height": 25,
+  "id": "UNIQUE_ID",
+  "index": "a1",
+  "isDeleted": false,
+  "lineHeight": 1.25,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "originalText": "Label",
+  "roughness": 1,
+  "roundness": null,
+  "seed": 1001,
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "text": "Label",
+  "textAlign": "center",
+  "type": "text",
+  "updated": 1700000000000,
+  "version": 1,
+  "verticalAlign": "middle",
+  "versionNonce": 1001,
+  "width": 100,
+  "x": 0,
+  "y": 0
 }
-
-> >
+>>
 
 ARROW_TEMPLATE: JSON<<
 {
-"id": "UNIQUE_ID",
-"type": "arrow",
-"x": 0,
-"y": 0,
-"width": 200,
-"height": 0,
-"angle": 0,
-"strokeColor": "#1e1e1e",
-"backgroundColor": "transparent",
-"fillStyle": "hachure",
-"strokeWidth": 2,
-"strokeStyle": "solid",
-"roughness": 1,
-"opacity": 100,
-"groupIds": [],
-"frameId": null,
-"index": "a2",
-"roundness": { "type": 2 },
-"seed": 1002,
-"version": 1,
-"versionNonce": 1002,
-"isDeleted": false,
-"boundElements": null,
-"updated": 1700000000000,
-"link": null,
-"locked": false,
-"points": [[0, 0], [200, 0]],
-"lastCommittedPoint": null,
-"startBinding": null,
-"endBinding": null,
-"startArrowhead": null,
-"endArrowhead": "arrow",
-"elbowed": false
+  "angle": 0,
+  "backgroundColor": "transparent",
+  "boundElements": null,
+  "elbowed": false,
+  "endArrowhead": "arrow",
+  "endBinding": null,
+  "fillStyle": "hachure",
+  "frameId": null,
+  "groupIds": [],
+  "height": 0,
+  "id": "UNIQUE_ID",
+  "index": "a2",
+  "isDeleted": false,
+  "lastCommittedPoint": null,
+  "link": null,
+  "locked": false,
+  "opacity": 100,
+  "points": [[0, 0], [200, 0]],
+  "roughness": 1,
+  "roundness": {"type": 2},
+  "seed": 1002,
+  "startArrowhead": null,
+  "startBinding": null,
+  "strokeColor": "#1e1e1e",
+  "strokeStyle": "solid",
+  "strokeWidth": 2,
+  "type": "arrow",
+  "updated": 1700000000000,
+  "version": 1,
+  "versionNonce": 1002,
+  "width": 200,
+  "x": 0,
+  "y": 0
 }
-
-> >
+>>
 
 BINDING_EXAMPLE: TEXT<<
 To bind text inside a shape:
@@ -227,21 +223,20 @@ To connect shapes with arrows:
 2. startBinding: {"elementId": "source-shape-id", "focus": 0, "gap": 5}
 3. endBinding: {"elementId": "target-shape-id", "focus": 0, "gap": 5}
 4. Also add the arrow to each shape's boundElements array
-   > >
+>>
 
 INDEX_SEQUENCE: TEXT<<
 Excalidraw uses fractional indexing for element ordering.
 Use a simple sequence: a0, a1, a2, ... a9, aA, aB, ... aZ, b0, b1, ...
 For elements that should appear in front, use later indices.
-
-> >
+>>
 
 SEED_RULES: TEXT<<
 Each element needs unique seed and versionNonce values.
 Use incrementing integers starting from 1000.
 seed and versionNonce can be the same value for an element.
-
-> > </constants>
+>>
+</constants>
 
 <formats>
 <format id="EXCALIDRAW_FILE" name="Excalidraw JSON Document" purpose="Complete Excalidraw file ready to save">
@@ -253,25 +248,25 @@ The JSON MUST:
 - Include "appState" with grid settings
 - Include empty "files" object (unless images are used)
 WHERE:
-- All element IDs are unique strings
-- All boundElements references point to valid IDs
-- All containerId values point to valid shape IDs
-- All binding elementId values point to valid shape IDs
-- Coordinates use positive integers
-- Colors use hex format (#rrggbb)
+- All element <ID_REF> values are unique strings.
+- All <BOUND_ELEM_REF> references point to valid IDs.
+- All <CONTAINER_REF> values point to valid shape IDs.
+- All <BINDING_REF> values point to valid shape IDs.
+- <COORDINATES> use positive integers.
+- <COLORS> use hex format (#rrggbb).
 </format>
 
 <format id="ELEMENT_LIST" name="Element Summary" purpose="Quick overview of diagram elements">
 ## Elements Created
 | ID | Type | Label/Purpose | Position |
 |----|------|---------------|----------|
-| <ID> | <TYPE> | <LABEL> | (<X>, <Y>) |
-...
+| <ELEMENT_ID> | <ELEMENT_TYPE> | <ELEMENT_LABEL> | (<POS_X>, <POS_Y>) |
 WHERE:
-- <ID> is the element's unique identifier
-- <TYPE> is rectangle, text, arrow, etc.
-- <LABEL> is the text content or purpose description
-- <X>, <Y> are the top-left coordinates
+- <ELEMENT_ID> is String; the element's unique identifier.
+- <ELEMENT_TYPE> is String; rectangle, text, arrow, etc.
+- <ELEMENT_LABEL> is String; the text content or purpose description.
+- <POS_X> is Integer; the left coordinate.
+- <POS_Y> is Integer; the top coordinate.
 </format>
 </formats>
 
@@ -296,32 +291,20 @@ RUN `generate_diagram`
 
 <process id="analyze_existing" name="Analyze Existing Excalidraw Files">
 USE `search/fileSearch` where: pattern="**/*.excalidraw"
-FOREACH file in results:
+FOREACH file IN results:
   USE `read/readFile` where: filePath=file
-  CAPTURE structure patterns and styling conventions
-RETURN: patterns for consistent styling
+  CAPTURE STYLE_PATTERNS from `read/readFile`
+RETURN: STYLE_PATTERNS
 </process>
 
 <process id="generate_diagram" name="Generate Excalidraw Diagram">
-PARSE DIAGRAM_DESCRIPTION to identify:
-  - Layout type (flowchart, wireframe, architecture, sequence)
-  - Required elements (boxes, arrows, text)
-  - Relationships between elements
-  - Color coding requirements
-
-CALCULATE positions based on:
-
-- Element count and sizes
-- Connection patterns
-- Visual balance and spacing (minimum 20px gaps)
-
-BUILD elements array using templates from constants
-ENSURE all IDs are unique
-ENSURE all bindings reference valid IDs
-ENSURE index values are sequential
-
+SET LAYOUT := <LAYOUT_TYPE> (from "Agent Inference" using DIAGRAM_DESCRIPTION)
+SET ELEMENT_SPECS := <SPECS> (from "Agent Inference" using DIAGRAM_DESCRIPTION)
+SET POSITIONS := <POS_MAP> (from "Agent Inference" using ELEMENT_SPECS)
+SET ELEMENTS := <ELEMENTS_ARRAY> (from "Agent Inference" using ELEMENT_SPECS, POSITIONS, EXCALIDRAW_TEMPLATE, RECTANGLE_TEMPLATE, TEXT_TEMPLATE, ARROW_TEMPLATE)
+ASSERT ALL: [all IDs are unique, all bindings reference valid IDs, index values are sequential]
 IF OUTPUT_PATH is specified:
-USE `edit/createFile` where: filePath=OUTPUT_PATH, content=JSON
+  USE `edit/createFile` where: content=ELEMENTS, filePath=OUTPUT_PATH
 RETURN: format="EXCALIDRAW_FILE"
 </process>
 </processes>

--- a/.github/skills/agnostic-prompt-standard/SKILL.md
+++ b/.github/skills/agnostic-prompt-standard/SKILL.md
@@ -7,7 +7,7 @@ metadata:
   author: "Christopher Buckley"
   co_authors: "Juan Burckhardt; Anastasiya Smirnova"
   spec_version: "1.0"
-  framework_revision: "1.1.10"
+  framework_revision: "1.1.11"
   last_updated: "2026-01-15"
 ---
 
@@ -46,6 +46,7 @@ This `SKILL.md` is the **entrypoint** for the Agnostic Prompt Standard (APS) v1.
     - `format-ideation-list-v1.0.0.example.md`
     - `format-link-manifest-v1.0.0.example.md`
     - `format-markdown-table-v1.0.0.example.md`
+    - `format-smeac-plan-v1.0.0.example.md`
     - `format-table-api-coverage-v1.0.0.example.md`
 - `platforms/` — **non-normative** platform adapters (file conventions, frontmatter, tool registries, templates).
   - `README.md` — platforms overview and contract.

--- a/.github/skills/agnostic-prompt-standard/assets/formats/format-smeac-plan-v1.0.0.example.md
+++ b/.github/skills/agnostic-prompt-standard/assets/formats/format-smeac-plan-v1.0.0.example.md
@@ -1,0 +1,186 @@
+```markdown
+<format id="SMEAC_PLAN_V1" name="SMEAC Plan" purpose="Structured planning brief covering situation, mission, execution phases, logistics, and command.">
+# <PLAN_TITLE>
+
+**Prepared:** <TIMESTAMP>
+**Classification:** <CLASSIFICATION>
+
+---
+
+## 1. Situation
+
+### Operating Environment
+<OPERATING_ENVIRONMENT>
+
+### Current State
+<CURRENT_STATE>
+
+### Challenges & Obstacles
+- <OBSTACLE>: <OBSTACLE_ASSESSMENT>
+…
+
+### Supporting Factors
+- **Higher intent:** <HIGHER_INTENT>
+- **Adjacent efforts:** <ADJACENT_EFFORTS>
+- **Supporting resources:** <SUPPORTING_RESOURCES>
+
+### Assumptions
+- <ASSUMPTION>
+…
+
+### Constraints & Limitations
+- **Constraint:** <CONSTRAINT>
+- **Limitation:** <LIMITATION>
+…
+
+---
+
+## 2. Mission
+
+<MISSION_STATEMENT>
+
+### Task
+<TASK>
+
+### Purpose
+<PURPOSE>
+
+### End State
+<END_STATE>
+
+---
+
+## 3. Execution
+
+### Leader's Intent
+<LEADERS_INTENT>
+
+### Concept of Operations
+<CONCEPT_OF_OPERATIONS>
+
+### Phases
+
+#### Phase <PHASE_NUMBER>: <PHASE_NAME>
+- **Objective:** <PHASE_OBJECTIVE>
+- **Key tasks:**
+  - <PHASE_TASK>
+  …
+- **Success criteria:** <PHASE_SUCCESS_CRITERIA>
+- **Transition trigger:** <TRANSITION_TRIGGER>
+…
+
+### Coordinating Instructions
+- **Timeline:** <TIMELINE>
+- **Boundaries:** <BOUNDARIES>
+- **Operating guidelines:** <OPERATING_GUIDELINES>
+- **Risk mitigation:** <RISK_MITIGATION>
+
+### Contingencies
+- **If** <CONTINGENCY_CONDITION> **then** <CONTINGENCY_ACTION>
+…
+
+---
+
+## 4. Admin & Logistics
+
+### Resources Required
+| Resource | Quantity | Source | Status |
+| --- | --- | --- | --- |
+| <RESOURCE_NAME> | <RESOURCE_QUANTITY> | <RESOURCE_SOURCE> | <RESOURCE_STATUS> |
+…
+
+### Supply & Provisioning
+<SUPPLY_PLAN>
+
+### Transportation & Movement
+<TRANSPORTATION_PLAN>
+
+### Sustainment
+<SUSTAINMENT_PLAN>
+
+### Recovery / Rollback Plan
+<ROLLBACK_PLAN>
+
+---
+
+## 5. Command & Signal
+
+### Decision Chain
+1. <PRIMARY_LEAD>
+2. <SUCCESSOR_LEAD>
+…
+
+### Communications Plan
+| Channel | Medium | Purpose | Cadence |
+| --- | --- | --- | --- |
+| <CHANNEL_NAME> | <CHANNEL_MEDIUM> | <CHANNEL_PURPOSE> | <CHANNEL_CADENCE> |
+…
+
+### Reporting Requirements
+- <REPORTING_REQUIREMENT>
+…
+
+### Decision Authority
+| Decision | Authority | Escalation |
+| --- | --- | --- |
+| <DECISION_TYPE> | <DECISION_AUTHORITY> | <ESCALATION_PATH> |
+…
+
+### Acknowledgement
+All parties MUST acknowledge receipt and understanding of this plan.
+
+---
+
+WHERE:
+- <PLAN_TITLE> is String; concise name for the plan or operation.
+- <TIMESTAMP> is ISO8601; date/time the plan was prepared.
+- <CLASSIFICATION> is one of: PUBLIC, INTERNAL, CONFIDENTIAL, RESTRICTED.
+- <OPERATING_ENVIRONMENT> is String; 1–3 sentences; describes the domain, environment, or scope of operations.
+- <CURRENT_STATE> is String; 1–3 sentences; factual assessment of the current situation and relevant background.
+- <OBSTACLE> is String; name or category of a challenge, competitor, blocker, or risk.
+- <OBSTACLE_ASSESSMENT> is String; impact, likelihood, and probable course of action for the obstacle.
+- <HIGHER_INTENT> is String; the overarching goal from leadership or strategy that this plan supports.
+- <ADJACENT_EFFORTS> is String; related parallel initiatives, teams, or workstreams and their relevance.
+- <SUPPORTING_RESOURCES> is String; available assets, teams, tools, or capabilities that can be leveraged.
+- <ASSUMPTION> is String; a condition assumed to be true for planning purposes; must be validated before or during execution.
+- <CONSTRAINT> is String; a restriction imposed by leadership or policy that limits freedom of action (MUST do or MUST NOT do).
+- <LIMITATION> is String; a shortcoming in capability or resource that restricts options.
+- <MISSION_STATEMENT> is String; single sentence; answers who, what, when, where, and why; active voice; present tense.
+- <TASK> is String; the specific action to be accomplished; measurable and time-bound.
+- <PURPOSE> is String; the reason the task matters; links to higher intent.
+- <END_STATE> is String; describes the desired conditions when the mission is complete.
+- <LEADERS_INTENT> is String; 2–4 sentences; states the purpose, key tasks, and desired end state in the leader's own framing.
+- <CONCEPT_OF_OPERATIONS> is String; 2–5 sentences; high-level approach describing how phases combine to achieve the mission.
+- <PHASE_NUMBER> is Integer; sequential from 1.
+- <PHASE_NAME> is String; short descriptive name for the phase (e.g., "Preparation", "Execution", "Consolidation").
+- <PHASE_OBJECTIVE> is String; what this phase aims to achieve.
+- <PHASE_TASK> is String; a discrete task within the phase; actionable and assignable.
+- <PHASE_SUCCESS_CRITERIA> is String; measurable conditions that indicate the phase objective is met.
+- <TRANSITION_TRIGGER> is String; the event or condition that signals transition to the next phase; last phase uses "Mission complete" or equivalent.
+- <TIMELINE> is String; key dates, deadlines, or time windows for execution.
+- <BOUNDARIES> is String; scope limits, geographic or logical boundaries, and deconfliction lines.
+- <OPERATING_GUIDELINES> is String; guidelines governing actions, decisions, and interactions during execution.
+- <RISK_MITIGATION> is String; identified risks and their mitigations.
+- <CONTINGENCY_CONDITION> is String; a specific adverse event or deviation from plan.
+- <CONTINGENCY_ACTION> is String; the prescribed response to the contingency condition.
+- <RESOURCE_NAME> is String; name or type of resource (personnel, equipment, budget, tooling, etc.).
+- <RESOURCE_QUANTITY> is String; amount or count required.
+- <RESOURCE_SOURCE> is String; where the resource comes from (team, vendor, budget line, etc.).
+- <RESOURCE_STATUS> is one of: AVAILABLE, REQUESTED, PENDING, AT_RISK, UNAVAILABLE.
+- <SUPPLY_PLAN> is String; 1–3 sentences; how consumable resources will be sourced and distributed.
+- <TRANSPORTATION_PLAN> is String; 1–3 sentences; how assets, deliverables, or personnel move between locations or stages.
+- <SUSTAINMENT_PLAN> is String; 1–3 sentences; how the operation will be maintained over its duration.
+- <ROLLBACK_PLAN> is String; 1–3 sentences; procedure for reverting or recovering if execution fails.
+- <PRIMARY_LEAD> is String; name and role of the primary decision-maker.
+- <SUCCESSOR_LEAD> is String; name and role of the next in line; at least one successor required.
+- <CHANNEL_NAME> is String; identifier for the communication channel (e.g., "Primary", "Backup", "Emergency").
+- <CHANNEL_MEDIUM> is String; the medium of communication (e.g., "Slack", "Email", "Teams", "In-person").
+- <CHANNEL_PURPOSE> is String; what this channel is used for (e.g., "Coordination", "Status updates", "Escalation").
+- <CHANNEL_CADENCE> is String; frequency of communication (e.g., "Real-time", "Daily standup", "On event").
+- <REPORTING_REQUIREMENT> is String; a specific report, metric, or status update expected during or after execution.
+- <DECISION_TYPE> is String; category of decision (e.g., "Go/No-go", "Resource allocation", "Scope change").
+- <DECISION_AUTHORITY> is String; who has authority to make this decision.
+- <ESCALATION_PATH> is String; who to escalate to if the primary authority is unavailable.
+- … denotes repetition; items follow the same pattern for each entry in the section.
+</format>
+```

--- a/.github/skills/agnostic-prompt-standard/platforms/claude-code/manifest.json
+++ b/.github/skills/agnostic-prompt-standard/platforms/claude-code/manifest.json
@@ -81,7 +81,7 @@
     "templates": [
       {
         "path": "templates/.claude/agents/aps-v{major}.{minor}.{patch}.md",
-        "currentPath": "templates/.claude/agents/aps-v1.1.10.md",
+        "currentPath": "templates/.claude/agents/aps-v1.1.11.md",
         "frontmatter": {
           "name": {
             "pattern": "aps-v{major}-{minor}-{patch}"

--- a/.github/skills/agnostic-prompt-standard/platforms/claude-code/templates/.claude/agents/aps-v1.1.11.md
+++ b/.github/skills/agnostic-prompt-standard/platforms/claude-code/templates/.claude/agents/aps-v1.1.11.md
@@ -1,16 +1,10 @@
 ---
-name: APS v1.1.10 Agent
-description: "Generate APS v1.1.10 .agent.md or .prompt.md files: detect artifact type from user intent, load APS+VS Code adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
-tools:
-  - execute/runInTerminal
-  - read/readFile
-  - edit/createDirectory
-  - edit/createFile
-  - edit/editFiles
-  - web/fetch
-  - todo
-infer: true
-target: vscode
+name: aps-v1-1-11
+description: "Generate APS v1.1.11 agent files for any platform: load APS skill + target platform adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
+model: inherit
+tools: Read, Write, Glob, Grep, Bash, TodoWrite
+disallowedTools: Edit, MultiEdit
+permissionMode: default
 ---
 
 <instructions>
@@ -51,10 +45,10 @@ You MUST consult SECTION_GUIDE when composing each section in generated agents.
 </instructions>
 
 <constants>
-SKILL_PATH: ".github/skills/agnostic-prompt-standard/SKILL.md"
-SKILL_PATH_ALT: ".claude/skills/agnostic-prompt-standard/SKILL.md"
-PLATFORMS_BASE: ".github/skills/agnostic-prompt-standard/platforms"
-PLATFORMS_BASE_ALT: ".claude/skills/agnostic-prompt-standard/platforms"
+SKILL_PATH: ".claude/skills/agnostic-prompt-standard/SKILL.md"
+SKILL_PATH_ALT: ".github/skills/agnostic-prompt-standard/SKILL.md"
+PLATFORMS_BASE: ".claude/skills/agnostic-prompt-standard/platforms"
+PLATFORMS_BASE_ALT: ".github/skills/agnostic-prompt-standard/platforms"
 CTA: "Reply with letter choices (e.g., '1a, 2c') or 'ok' to accept defaults."
 
 PLATFORMS: JSON
@@ -386,14 +380,16 @@ RETURN: format="OUT_V1", agent_name=AGENT_SLUG, file_path=FILE_PATH, lint=LINT, 
 
 <process id="init" name="Init+Load Skill">
 SET SESSION_INIT := true (from "Agent Inference")
-READ file at SKILL_PATH or SKILL_PATH_ALT
-CAPTURE SKILL_CONTENT from read result
+USE `Glob` where: pattern=".claude/skills/agnostic-prompt-standard/SKILL.md,.github/skills/agnostic-prompt-standard/SKILL.md"
+CAPTURE SKILL_PATHS from `Glob`
+USE `Read` where: filePath=SKILL_PATHS[0]
+CAPTURE SKILL_CONTENT from `Read`
 </process>
 
 <process id="ask-platform" name="Ask Target Platform">
 SET STATE := "Selecting target platform" (from "Agent Inference")
 SET INTENT := "Target platform not yet selected" (from "Agent Inference")
-SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) VS Code Copilot (.github/agents/*.agent.md)\n  b) Claude Code (.claude/agents/*.md)\n  c) Other (specify)\n  d) Same as current platform (VS Code Copilot)\n  e) None / Cancel" (from "Agent Inference")
+SET QUESTIONS := "Q1: Which platform do you want to generate an agent for?\n  a) VS Code Copilot (.github/agents/*.agent.md)\n  b) Claude Code (.claude/agents/*.md)\n  c) Other (specify)\n  d) Same as current platform (Claude Code)\n  e) None / Cancel" (from "Agent Inference")
 SET TARGET_PLATFORM := <PLATFORM_ID> (from "Agent Inference" using USER_INPUT, PLATFORMS)
 IF TARGET_PLATFORM is not empty:
   RUN `load-platform`
@@ -403,10 +399,22 @@ IF TARGET_PLATFORM is not empty:
 SET PLATFORM_CONFIG := <CONFIG> (from "Agent Inference" using TARGET_PLATFORM, PLATFORMS)
 SET FRONTMATTER_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE, PLATFORM_CONFIG.frontmatterPath)
 SET TOOLS_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE, PLATFORM_CONFIG.toolsRegistryPath)
-READ file at FRONTMATTER_PATH (fallback to PLATFORMS_BASE_ALT if not found)
-CAPTURE FRONTMATTER_TEMPLATE from read result
-READ file at TOOLS_PATH (fallback to PLATFORMS_BASE_ALT if not found)
-CAPTURE ADAPTER_TOOLS from read result
+USE `Glob` where: pattern=FRONTMATTER_PATH
+CAPTURE FRONTMATTER_PATHS from `Glob`
+IF FRONTMATTER_PATHS is empty:
+  SET FRONTMATTER_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE_ALT, PLATFORM_CONFIG.frontmatterPath)
+  USE `Glob` where: pattern=FRONTMATTER_PATH
+  CAPTURE FRONTMATTER_PATHS from `Glob`
+USE `Read` where: filePath=FRONTMATTER_PATHS[0]
+CAPTURE FRONTMATTER_TEMPLATE from `Read`
+USE `Glob` where: pattern=TOOLS_PATH
+CAPTURE TOOLS_PATHS from `Glob`
+IF TOOLS_PATHS is empty:
+  SET TOOLS_PATH := <PATH> (from "Agent Inference" using PLATFORMS_BASE_ALT, PLATFORM_CONFIG.toolsRegistryPath)
+  USE `Glob` where: pattern=TOOLS_PATH
+  CAPTURE TOOLS_PATHS from `Glob`
+USE `Read` where: filePath=TOOLS_PATHS[0]
+CAPTURE ADAPTER_TOOLS from `Read`
 IF TARGET_PLATFORM = "claude-code":
   SET FIELD_REQUIREMENTS := FIELD_REQUIREMENTS_CLAUDE (from "Constant Lookup")
 ELSE:
@@ -427,8 +435,8 @@ ELSE:
   SET AGENT_SLUG := <SLUG> (from "Agent Inference" using INTENT, SLUG_RULES_VSCODE)
 SET FILE_PATH := <AGENT_FILE_PATH> (from "Agent Inference" using AGENT_SLUG, PLATFORM_CONFIG.agentsDir, PLATFORM_CONFIG.agentExt)
 SET AGENT := <AGENT_TEXT> (from "Agent Inference" using INTENT, SKILL_CONTENT, FRONTMATTER_TEMPLATE, ADAPTER_TOOLS, AGENT_SKELETON, PLATFORM_CONFIG, FIELD_REQUIREMENTS, SECTION_GUIDE, CROSS_REF, APS_NAMING, COMMON_ERRORS, TOOL_SELECTION, VOCAB_RULES)
-USE `edit/createDirectory` where: dirPath=PLATFORM_CONFIG.agentsDir
-USE `edit/createFile` where: filePath=FILE_PATH, content=AGENT
+USE `Bash` where: command="mkdir -p " + PLATFORM_CONFIG.agentsDir
+USE `Write` where: filePath=FILE_PATH, content=AGENT
 SET LINT := <LINT_TEXT> (from "Agent Inference" using AGENT, LINT_CHECKS, TARGET_PLATFORM, FIELD_REQUIREMENTS, COMMON_ERRORS)
 SET LINT_CLEAN := <IS_CLEAN> (from "Agent Inference" using LINT)
 </process>

--- a/.github/skills/agnostic-prompt-standard/platforms/vscode-copilot/manifest.json
+++ b/.github/skills/agnostic-prompt-standard/platforms/vscode-copilot/manifest.json
@@ -47,7 +47,7 @@
     "templates": [
       {
         "path": "templates/.github/agents/aps-v{major}.{minor}.{patch}.agent.md",
-        "currentPath": "templates/.github/agents/aps-v1.1.10.agent.md",
+        "currentPath": "templates/.github/agents/aps-v1.1.11.agent.md",
         "frontmatter": {
           "name": {
             "pattern": "APS v{major}.{minor}.{patch} Agent"

--- a/.github/skills/agnostic-prompt-standard/platforms/vscode-copilot/templates/.github/agents/aps-v1.1.11.agent.md
+++ b/.github/skills/agnostic-prompt-standard/platforms/vscode-copilot/templates/.github/agents/aps-v1.1.11.agent.md
@@ -1,6 +1,6 @@
 ---
-name: APS v1.1.10 Agent
-description: "Generate APS v1.1.10 .agent.md or .prompt.md files: detect artifact type from user intent, load APS+VS Code adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
+name: APS v1.1.11 Agent
+description: "Generate APS v1.1.11 .agent.md or .prompt.md files: detect artifact type from user intent, load APS+VS Code adapter, extract intent, then generate+write+lint. Author: Christopher Buckley. Co-authors: Juan Burckhardt, Anastasiya Smirnova. URL: https://github.com/chris-buckley/agnostic-prompt-standard"
 tools:
   - execute/runInTerminal
   - read/readFile
@@ -9,7 +9,8 @@ tools:
   - edit/editFiles
   - web/fetch
   - todo
-infer: true
+user-invokable: true
+disable-model-invocation: true
 target: vscode
 ---
 
@@ -57,61 +58,63 @@ PLATFORMS_BASE: ".github/skills/agnostic-prompt-standard/platforms"
 PLATFORMS_BASE_ALT: ".claude/skills/agnostic-prompt-standard/platforms"
 CTA: "Reply with letter choices (e.g., '1a, 2c') or 'ok' to accept defaults."
 
-PLATFORMS: JSON
+PLATFORMS: JSON<<
 {
-"vscode-copilot": {
-"displayName": "VS Code Copilot",
-"frontmatterPath": "vscode-copilot/frontmatter/agent-frontmatter.md",
-"toolsRegistryPath": "vscode-copilot/tools-registry.json",
-"agentsDir": ".github/agents/",
-"agentExt": ".agent.md",
-"toolSyntax": "yaml-array"
-},
-"claude-code": {
-"displayName": "Claude Code",
-"frontmatterPath": "claude-code/frontmatter/agent-frontmatter.md",
-"toolsRegistryPath": "claude-code/tools-registry.json",
-"agentsDir": ".claude/agents/",
-"agentExt": ".md",
-"toolSyntax": "comma-separated"
-}
+  "vscode-copilot": {
+    "displayName": "VS Code Copilot",
+    "frontmatterPath": "vscode-copilot/frontmatter/agent-frontmatter.md",
+    "toolsRegistryPath": "vscode-copilot/tools-registry.json",
+    "agentsDir": ".github/agents/",
+    "agentExt": ".agent.md",
+    "toolSyntax": "yaml-array"
+  },
+  "claude-code": {
+    "displayName": "Claude Code",
+    "frontmatterPath": "claude-code/frontmatter/agent-frontmatter.md",
+    "toolsRegistryPath": "claude-code/tools-registry.json",
+    "agentsDir": ".claude/agents/",
+    "agentExt": ".md",
+    "toolSyntax": "comma-separated"
+  }
 }
 >>
 
-FIELD_REQUIREMENTS_VSCODE: JSON
+FIELD_REQUIREMENTS_VSCODE: JSON<<
 {
-"required": ["name", "description"],
-"recommended": {
-"tools": [],
-"infer": true,
-"target": "vscode"
-},
-"conditional": ["model", "argument-hint", "mcp-servers", "handoffs"],
-"fieldOrder": ["name", "description", "tools", "infer", "target", "model", "argument-hint", "mcp-servers", "handoffs"]
+  "required": ["name", "description"],
+  "recommended": {
+    "tools": [],
+    "user-invokable": true,
+    "disable-model-invocation": false,
+    "target": "vscode"
+  },
+  "conditional": ["model", "argument-hint", "agents", "mcp-servers", "handoffs"],
+  "fieldOrder": ["name", "description", "tools", "user-invokable", "disable-model-invocation", "target", "model", "argument-hint", "agents", "mcp-servers", "handoffs"],
+  "deprecated": ["infer"]
 }
 >>
 
-FIELD_REQUIREMENTS_CLAUDE: JSON
+FIELD_REQUIREMENTS_CLAUDE: JSON<<
 {
-"required": ["name", "description"],
-"recommended": {
-"tools": "Read, Grep, Glob",
-"model": "inherit",
-"permissionMode": "default"
-},
-"conditional": ["disallowedTools", "skills", "hooks"],
-"fieldOrder": ["name", "description", "tools", "model", "permissionMode", "disallowedTools", "skills", "hooks"]
+  "required": ["name", "description"],
+  "recommended": {
+    "tools": "Read, Grep, Glob",
+    "model": "inherit",
+    "permissionMode": "default"
+  },
+  "conditional": ["disallowedTools", "skills", "hooks"],
+  "fieldOrder": ["name", "description", "tools", "model", "permissionMode", "disallowedTools", "skills", "hooks"]
 }
 >>
 
-SLUG_RULES_VSCODE: TEXT
+SLUG_RULES_VSCODE: TEXT<<
 - lowercase ascii
 - space/\_ -> -
 - keep [a-z0-9-]
 - collapse/trim -
 >>
 
-SLUG_RULES_CLAUDE: TEXT
+SLUG_RULES_CLAUDE: TEXT<<
 - lowercase ascii
 - space/\_ -> -
 - keep [a-z0-9-]
@@ -119,7 +122,7 @@ SLUG_RULES_CLAUDE: TEXT
 - name field must be unique identifier (lowercase, hyphens only)
 >>
 
-ASK_RULES: TEXT
+ASK_RULES: TEXT<<
 - ask only what blocks agent generation
 - 0-2 questions per turn
 - each question MUST have 4 suggested answers (a-d) plus option (e) for "all of the above" or "none/other"
@@ -136,7 +139,7 @@ ASK_RULES: TEXT
 - MUST prompt for description if not provided
 >>
 
-LINT_CHECKS: TEXT
+LINT_CHECKS: TEXT<<
 - section order: instructions, constants, formats, runtime, triggers, processes, input
 - tag newline rule
 - no tabs
@@ -152,7 +155,8 @@ LINT_CHECKS: TEXT
 - all Recommended fields are present with defaults if not overridden
 - Conditional fields only present when explicitly specified
 - no YAML comments in frontmatter output
-- VS Code: tools is YAML array, infer is boolean, target is string
+- VS Code: tools is YAML array, user-invokable is boolean, disable-model-invocation is boolean, target is string
+- VS Code: deprecated `infer` field MUST NOT appear in generated frontmatter
 - Claude Code: tools is comma-separated string, model is string, permissionMode is string
 - generated <instructions> use MUST/SHOULD/MAY vocabulary correctly
 - generated <instructions> has one directive per line with no blank lines
@@ -161,7 +165,7 @@ LINT_CHECKS: TEXT
 - generated <constants> use YAML blocks for structured data unless JSON is the target format
 >>
 
-AGENT_SKELETON: TEXT
+AGENT_SKELETON: TEXT<<
 <instructions>\n...\n</instructions>\n<constants>\n...\n</constants>\n<formats>\n...\n</formats>\n<runtime>\n...\n</runtime>\n<triggers>\n...\n</triggers>\n<processes>\n...\n</processes>\n<input>\n...\n</input>
 >>
 

--- a/.github/skills/agnostic-prompt-standard/references/04-schemas-and-types.md
+++ b/.github/skills/agnostic-prompt-standard/references/04-schemas-and-types.md
@@ -126,6 +126,7 @@ Style guidelines:
 - Hierarchical outline: [../assets/formats/format-hierarchical-outline-v1.0.0.example.md](../assets/formats/format-hierarchical-outline-v1.0.0.example.md)
 - Markdown table: [../assets/formats/format-markdown-table-v1.0.0.example.md](../assets/formats/format-markdown-table-v1.0.0.example.md)
 - Code changes full: [../assets/formats/format-code-changes-full-v1.0.0.example.md](../assets/formats/format-code-changes-full-v1.0.0.example.md)
+- SMEAC plan: [../assets/formats/format-smeac-plan-v1.0.0.example.md](../assets/formats/format-smeac-plan-v1.0.0.example.md)
 
 ## Example constants
 


### PR DESCRIPTION
## Summary

Updates all four custom agents to conform with APS v1.1.11 spec and updates the APS skill framework itself from v1.1.10 to v1.1.11.

## Changes

### Agent frontmatter (all files)
- Added missing recommended fields: `disable-model-invocation`, `target`
- Enforced field ordering: Required → Recommended → Conditional
- Converted bracket-notation tools to YAML array syntax
- Replaced toolset names with qualified tool names where appropriate

### excali.agent.md
- Added missing `name` field
- Fixed 10 broken `>>` block constant delimiters (`> >` → `>>`)
- Canonicalized JSON keys to lexicographic order
- Rewrote informal instructions to MUST vocabulary
- Converted process DSL to use `SET`/`CAPTURE`/`ASSERT`

### module-executor.agent.md
- Fixed `FOR EACH` → `FOREACH` (DSL keyword)
- Replaced `EXTRACT`/`EVALUATE`/`APPEND` with proper `SET` syntax

### workshop-content-manager.agent.md
- Replaced toolset names (`search`, `read`, `edit`) with qualified names
- Removed nonexistent `fetch_copilot_cli_documentation` tool reference
- Replaced informal DSL (`COMPARE`/`PRESENT`/`AWAIT`/`DISPLAY`) with `SET`/`TELL`/`RETURN`

### workshop-runner.agent.md
- Replaced `agent` toolset with `agent/runSubagent` qualified name
- Fixed `PARALLEL FOR EACH`/`END PARALLEL` → `PAR:`/`JOIN:`
- Fixed `FOR EACH` → `FOREACH`

### APS Skill Framework
- Updated from v1.1.10 to v1.1.11