### PR TITLE
chore: add postCreateCommand and post-create script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,6 +65,7 @@
         // "UV_PROJECT_ENVIRONMENT": "/home/vscode/.venv",
         // "PYTHONPATH": "/workspaces/101-copilot-sdd/src:${PYTHONPATH}"
     // },
+    "postCreateCommand": "bash ./.devcontainer/post-create.sh",
     "remoteUser": "vscode",
     "hostRequirements": {
         "memory": "4gb"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Installing missing system binaries..."
+sudo apt-get update -qq
+sudo apt-get install -y --no-install-recommends xdg-utils xclip
+echo "post-create.sh completed successfully."


### PR DESCRIPTION
Add a `postCreateCommand` to `devcontainer.json` that runs a post-create script to install missing system binaries (`xdg-utils`, `xclip`).