### PR TITLE
Glav/remove llm txt

### DIFF
--- a/docs/workshop/04-instructions.md
+++ b/docs/workshop/04-instructions.md
@@ -29,7 +29,7 @@ Copilot CLI reads instructions from multiple sources with this priority:
 6. Default behavior (lowest)
 ```
 
-*Note: `llm.txt` for copilot instructions is currently listed as an issue to be implemented. This file currently can be located within websites to allow models/LLM's to better consume and navigate the site.*
+*Note: `llm.txt` for copilot instructions is currently listed as an issue to be implemented. This file currently can be located within websites to allow models/LLM's to better consume and navigate the site. See [here](https://llmstxthub.com/) for examples*
 
 ### File Purposes
 


### PR DESCRIPTION
This pull request updates the documentation for Copilot instructions and exercises, clarifying the role of the `llm.txt` file and streamlining the workshop exercises. The most important changes include improved explanation of `llm.txt`, removal of the exercise for creating `llm.txt`, and renumbering subsequent exercises.

Documentation improvements:

* Added a note clarifying that `llm.txt` is not yet fully implemented for Copilot instructions and is intended to help models navigate websites; also updated the description in the file purposes table to emphasize its use for LLMs.

Workshop exercise changes:

* Removed the detailed exercise for creating `llm.txt`, including its goal, steps, and expected outcome, to reflect its current status as an unimplemented feature.
* Renumbered the exercises to account for the removal of the `llm.txt` exercise, ensuring consistency throughout the documentation.