### PR TITLE
chore: upgrade workshop content v1.0.7 → v1.0.16

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,7 +31,7 @@ REPO_STRUCTURE: TEXT
 
 WORKSHOP_FLOW: "Installation (01) -> Core Concepts (02-05) -> Advanced (06-13)"
 WORKSHOP_DURATION: "~4.5 hours"
-TESTED_VERSION: "GitHub Copilot CLI v1.0.7"
+TESTED_VERSION: "GitHub Copilot CLI v1.0.16"
 RELEASES_URL: "https://github.com/github/copilot-cli/releases"
 MODULE_COUNT: 13
 SLIDE_SYNC_RULE: "When modifying docs/workshop/NN-*.md, always check and update docs/slides/NN-*.md"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # 101-copilot-cli-sdd
 
-[![Copilot CLI version](https://img.shields.io/badge/Copilot%20CLI-v1.0.7-blue?logo=github)](https://github.com/github/copilot-cli/releases/tag/v1.0.7)
+[![Copilot CLI version](https://img.shields.io/badge/Copilot%20CLI-v1.0.16-blue?logo=github)](https://github.com/github/copilot-cli/releases/tag/v1.0.16)
 [![APS version](https://img.shields.io/badge/APS-v1.2.1-blue?logo=github)](https://github.com/chris-buckley/agnostic-prompt-standard/releases/tag/v1.2.1)
 
-A quick guide to use GitHub Copilot CLI (tested with **v1.0.7**) + a sample SDD (Specification-Driven Development) project
+A quick guide to use GitHub Copilot CLI (tested with **v1.0.16**) + a sample SDD (Specification-Driven Development) project
 
 ## Workshop
 

--- a/docs/slides/02-modes.md
+++ b/docs/slides/02-modes.md
@@ -167,10 +167,10 @@ Type **`/help`** to see them all
 | `ctrl+c` | Cancel / clear input / exit |
 | `ctrl+d` | Shutdown on empty prompt |
 | `ctrl+y` | Edit plan in terminal editor |
-| `ctrl+f` / `ctrl+b` | Page forward / back in alt-screen |
+| `ctrl+f` / `ctrl+b` | Page forward / back |
 | `ctrl+g` | Open prompt in external editor |
 
-> See workshop for 25+ additional shortcuts including text editing and alt-screen navigation
+> See workshop for 25+ additional shortcuts including text editing and navigation
 
 ---
 
@@ -189,14 +189,18 @@ When Copilot wants to run a command, you choose:
 
 ---
 
-## New in v1.0.3–v1.0.7
+## New in v1.0.3–v1.0.16
 
 - **`/restart`** — Hot restart preserving your session
-- **`/diff`** now has **syntax highlighting** (17 languages)
+- **`/diff`** now has **syntax highlighting** (17 languages) with Home/End and Page Up/Page Down navigation
 - **Branch indicator** in header: `main*+%`
   - `*` unstaged, `+` staged, `%` untracked
 - **`quit`** works as exit alias (alongside `/exit`)
-- **Double-Esc** — clears input or triggers undo
+- **Double-Esc** — opens timeline picker to roll back to any conversation point
+- **`/undo`** — Undo last turn and revert file changes
+- **`/new`** — Start fresh conversation (old session stays backgrounded)
+- **`/clear`** — Abandon session entirely
+- **`/allow-all [on|off|show]`** — Toggle or check allow-all mode
 
 ---
 

--- a/docs/slides/03-instructions.md
+++ b/docs/slides/03-instructions.md
@@ -166,7 +166,7 @@ Saved as `.github/instructions/tests.instructions.md`
 
 ---
 
-## New in v1.0.6–v1.0.7
+## New in v1.0.6–v1.0.16
 
 - **`applyTo`** now accepts **YAML arrays** (v1.0.6+):
   ```yaml
@@ -174,8 +174,9 @@ Saved as `.github/instructions/tests.instructions.md`
     - "**/*.ts"
     - "**/*.tsx"
   ```
-- **"Customize" mode** for system message overrides (v1.0.7)
+- **"Customize" mode** for system message overrides (v1.0.7+)
 - **`COPILOT_CUSTOM_INSTRUCTIONS_DIRS`** for extra instruction paths
+- **Monorepo discovery** — instructions found from cwd up to git root (v1.0.11+)
 
 ---
 

--- a/docs/slides/04-tools.md
+++ b/docs/slides/04-tools.md
@@ -127,7 +127,7 @@ copilot --yolo -p "Set up a Node.js project"
 
 ---
 
-## URL & Path Permissions (v1.0.x)
+## URL & Path Permissions
 
 ```bash
 # Allow/deny URL access

--- a/docs/slides/05-mcps.md
+++ b/docs/slides/05-mcps.md
@@ -164,7 +164,7 @@ All from inside a Copilot session:
 
 ---
 
-## GitHub MCP Server Controls (v1.0.x)
+## GitHub MCP Server Controls
 
 ```bash
 # Add specific tools/toolsets

--- a/docs/slides/09-hooks.md
+++ b/docs/slides/09-hooks.md
@@ -81,10 +81,12 @@ Use cases: **logging**, **security guardrails**, **auditing**, **alerts**
 | `sessionEnd` | Session ends | Cleanup, metrics |
 | `userPromptSubmitted` | User sends prompt | Audit trail |
 | `preToolUse` | Before tool runs | **Permission control** |
-| `postToolUse` | After tool runs | Verification, logging |
+| `postToolUse` | After successful tool run | Verification, logging |
+| `postToolUseFailure` | After tool failure | Error handling |
 | `errorOccurred` | Error happens | Alerts, monitoring |
 | `preCompact` | Before compaction | State saving (v1.0.5) |
 | `subagentStart` | Sub-agent spawned | Context injection (v1.0.7) |
+| `permissionRequest` | Permission requested | Programmatic approve/deny (v1.0.16) |
 
 ---
 
@@ -171,7 +173,7 @@ echo "[$(date -Iseconds)] $TOOL_NAME: $RESULT" >> logs/audit.log
 
 ---
 
-## New Hook Features (v1.0.4–v1.0.7)
+## New Hook Features (v1.0.4–v1.0.16)
 
 - **`disableAllHooks`** config flag — turn off all hooks (v1.0.4)
 - **`ask`** permission decision — prompt user for confirmation (v1.0.4):
@@ -180,6 +182,9 @@ echo "[$(date -Iseconds)] $TOOL_NAME: $RESULT" >> logs/audit.log
   ```
 - **Cross-platform compat** — PascalCase event names, Claude Code nested structure (v1.0.6)
 - Hook config files that **omit `version`** field now accepted (v1.0.5)
+- **`postToolUseFailure`** hook for tool errors; `postToolUse` fires only on success (v1.0.15)
+- **`permissionRequest`** hook for programmatic tool approval (v1.0.16)
+- Hooks can also be defined in **`settings.json`** and **`config.json`** (v1.0.8)
 
 ---
 

--- a/docs/slides/12-advanced.md
+++ b/docs/slides/12-advanced.md
@@ -81,10 +81,10 @@ style: |
 ```bash
 copilot --autopilot -p "Create an Express API with auth, tests, and docs"
 
-# Limit continuation rounds (v1.0.x)
+# Limit continuation rounds
 copilot --autopilot --max-autopilot-continues 10
 
-# Fully autonomous — no questions (v1.0.x)
+# Fully autonomous — no questions
 copilot --autopilot --no-ask-user --allow-all-tools
 ```
 
@@ -211,7 +211,7 @@ alias cop-resume='copilot --resume'
 
 ---
 
-## New in v1.0.3–v1.0.7
+## New in v1.0.3–v1.0.16
 
 - **`/pr`** — Full PR management: create, view, fix CI, review, merge conflicts (v1.0.5)
   - `/pr view local|web` replaces old `/pr open` (v1.0.4) ⚠️
@@ -219,6 +219,10 @@ alias cop-resume='copilot --resume'
 - **`/experimental on|off`** — Toggle with auto-restart (v1.0.5)
 - **Human-readable sub-agent IDs** (e.g., `math-helper-0`) (v1.0.6)
 - **`read_agent`** includes inbound messages for multi-turn agents (v1.0.6)
+- **`--effort`** — Shorthand for `--reasoning-effort` (v1.0.10)
+- **`/undo`** — Undo last turn and revert file changes (v1.0.10)
+- **Monorepo discovery** — instructions, MCPs, skills from cwd to git root (v1.0.11)
+- **`/rewind`** — Timeline picker to roll back to any point (v1.0.13)
 
 ---
 

--- a/docs/slides/13-configuration.md
+++ b/docs/slides/13-configuration.md
@@ -79,13 +79,12 @@ All settings live in `~/.copilot/config.json`:
 {
   "model": "claude-sonnet-4.6",
   "theme": "auto",
-  "alt_screen": false,
   "mouse": true,
   "beep": true,
-  "compact_paste": true,
-  "include_coauthor": true,
-  "update_terminal_title": true,
-  "streamer_mode": false
+  "compactPaste": true,
+  "includeCoauthor": true,
+  "updateTerminalTitle": true,
+  "streamerMode": false
 }
 ```
 
@@ -98,13 +97,13 @@ Override location: `COPILOT_HOME` env var or `--config-dir` flag
 | Option | Default | Description |
 |--------|---------|-------------|
 | `model` | (varies) | AI model |
-| `compact_paste` | `true` | Collapse large pastes |
-| `copy_on_select` | macOS only | Auto-copy selection |
-| `include_coauthor` | `true` | Co-authored-by in commits |
-| `streamer_mode` | `false` | Hide model names/quota |
+| `compactPaste` | `true` | Collapse large pastes |
+| `copyOnSelect` | macOS only | Auto-copy selection |
+| `includeCoauthor` | `true` | Co-authored-by in commits |
+| `streamerMode` | `false` | Hide model names/quota |
 | `companyAnnouncements` | `[]` | Team startup messages |
-| `ide.auto_connect` | `true` | Auto-connect to IDE |
-| `ide.open_diff_on_edit` | `true` | Diffs in IDE |
+| `ide.autoConnect` | `true` | Auto-connect to IDE |
+| `ide.openDiffOnEdit` | `true` | Diffs in IDE |
 
 ---
 
@@ -123,7 +122,7 @@ Override location: `COPILOT_HOME` env var or `--config-dir` flag
 
 ---
 
-## New CLI Flags (v1.0.x)
+## Additional CLI Flags
 
 | Flag | Purpose |
 |------|---------|
@@ -165,7 +164,7 @@ Config options:
     "Remember: never commit secrets",
     "Sprint 14 ends Friday"
   ],
-  "include_coauthor": true,
+  "includeCoauthor": true,
   "model": "gpt-4.1"
 }
 ```
@@ -174,17 +173,18 @@ Distribute via shared config templates in your repo.
 
 ---
 
-## New Config & Flags (v1.0.3–v1.0.7)
+## New Config & Flags (v1.0.3–v1.0.16)
 
 | Feature | Details |
 |---------|---------|
 | `mergeStrategy` | Replaces `merge_strategy` ⚠️ (v1.0.3) |
 | `--reasoning-effort` | Control model reasoning level (v1.0.4) |
+| `--effort` | Shorthand for `--reasoning-effort` (v1.0.10) |
 | `--binary-version` | Check version without launching (v1.0.3) |
 | `GH_HOST` | Override GitHub API hostname |
 | `HTTP_PROXY` / `HTTPS_PROXY` | Proxy support |
 | `NO_PROXY` | Bypass proxy for specific hosts |
-| gpt-5.4-mini | New model available (v1.0.7) |
+| camelCase config | All config keys now prefer camelCase (v1.0.10+) |
 
 ---
 

--- a/docs/workshop/00-index.md
+++ b/docs/workshop/00-index.md
@@ -1,6 +1,6 @@
 # GitHub Copilot CLI Workshop
 
-> **Tested against:** GitHub Copilot CLI **v1.0.7** (Generally Available, version 1.0 since v1.0.0). Check [releases](https://github.com/github/copilot-cli/releases) for newer versions — some features may change or new ones may be added.
+> **Tested against:** GitHub Copilot CLI **v1.0.16** (Generally Available, version 1.0 since v1.0.0). Check [releases](https://github.com/github/copilot-cli/releases) for newer versions — some features may change or new ones may be added.
 
 Welcome to this hands-on workshop for mastering GitHub Copilot CLI! This workshop will take you from installation to advanced automation techniques.
 
@@ -95,7 +95,8 @@ copilot --resume
 | Command | Description |
 | --- | --- |
 | `/help` | Show all available commands |
-| `/clear` | Clear session context |
+| `/clear` | Abandon session and start fresh |
+| `/new` | Start new conversation (old session stays backgrounded) |
 | `/context` | View token usage |
 | `/compact` | Compress session history |
 | `/plan` | Create implementation plan before coding |
@@ -108,6 +109,8 @@ copilot --resume
 | `/instructions` | View and toggle custom instruction files |
 | `/cwd` | Change working directory |
 | `/research` | Deep research with exportable reports |
+| `/undo` | Undo last turn and revert file changes |
+| `/rewind` | Roll back to any point in conversation history |
 | `/copy` | Copy last response to clipboard |
 | `/ide` | Connect to IDE workspace |
 | `/streamer-mode` | Toggle streamer mode |

--- a/docs/workshop/01-installation.md
+++ b/docs/workshop/01-installation.md
@@ -313,8 +313,6 @@ source ~/.bashrc
 
 ### Authentication with GitHub Enterprise Cloud (Data Residency)
 
-> ⚠️ **FEEDBACK**: GHEC data residency login with `--host` is available in **v1.0.x**. If your version is older, this flag may not be available.
-
 If your organization uses GitHub Enterprise Cloud with data residency, authenticate with the `--host` flag:
 
 ```bash

--- a/docs/workshop/02-modes.md
+++ b/docs/workshop/02-modes.md
@@ -32,8 +32,6 @@ copilot
 
 ### Interactive-with-Prompt Mode
 
-> ⚠️ **FEEDBACK**: The `-i, --interactive` flag is available in **v1.0.x**. If your version is older, use `-p` for prompt mode or start an interactive session and type your prompt.
-
 The `-i` flag starts an interactive session **and** automatically executes a prompt — combining the best of both modes. The session stays open for follow-up after the initial prompt completes.
 
 ```bash
@@ -55,7 +53,7 @@ Programmatic mode executes a single prompt and exits. Perfect for:
 # Execute a single prompt (exits after completion)
 copilot -p "summarize the README.md file"
 
-# JSON output for scripting (v1.0.x)
+# JSON output for scripting
 copilot -p "list all TODO comments" --output-format json
 
 # Silent mode — agent response only, no stats
@@ -88,14 +86,14 @@ Slash commands are prefixed with `/` and provide quick access to CLI features wi
 
 | Category | Commands | Purpose |
 | --- | --- | --- |
-| **Session** | `/clear`, `/session`, `/resume`, `/rename`, `/usage` | Manage session lifecycle |
+| **Session** | `/clear`, `/new`, `/session`, `/resume`, `/rename`, `/usage` | Manage session lifecycle |
 | **Navigation** | `/cwd`, `/cd`, `/add-dir`, `/list-dirs` | Control directory scope |
 | **Context** | `/context`, `/compact` | Monitor and optimize token usage |
-| **Tools** | `/allow-all`, `/yolo`, `/reset-allowed-tools` | Manage tool permissions at runtime |
-| **Review** | `/diff`, `/review`, `/plan`, `/research` | Code review, planning, and research workflows |
+| **Tools** | `/allow-all [on\|off\|show]`, `/yolo`, `/reset-allowed-tools` | Manage tool permissions at runtime |
+| **Review** | `/diff`, `/review`, `/plan`, `/research`, `/undo`, `/rewind` | Code review, planning, history navigation |
 | **Configuration** | `/model`, `/mcp`, `/theme`, `/terminal-setup`, `/experimental`, `/streamer-mode`, `/instructions` | Customize CLI behavior |
 | **Extensibility** | `/skills`, `/plugin`, `/agent`, `/fleet` | Manage skills, plugins, agents, and parallel execution |
-| **Sharing** | `/share`, `/feedback`, `/copy` | Export sessions, copy responses, and submit feedback |
+| **Sharing** | `/share`, `/share html`, `/feedback`, `/copy` | Export sessions, copy responses, and submit feedback |
 | **Account** | `/login`, `/logout`, `/user` | Authentication and user management |
 | **IDE** | `/ide` | Connect to IDE workspace |
 | **System** | `/help`, `/exit`, `/quit`, `/init`, `/tasks`, `/lsp`, `/update`, `/restart`, `/changelog`, `/chronicle` | General utilities and productivity |
@@ -126,23 +124,23 @@ In addition to slash commands, Copilot CLI supports keyboard shortcuts:
 | `ctrl+y` | Edit plan in terminal editor |
 | `ctrl+x → ctrl+e` | Edit prompt in terminal editor |
 | `ctrl+z` | Suspend/resume CLI (Unix platforms only) |
-| `ctrl+insert` | Copy selected text in alt-screen mode |
-| `ctrl+f` | Page forward in alt-screen mode |
-| `ctrl+b` | Page back in alt-screen mode |
+| `ctrl+insert` | Copy selected text |
+| `ctrl+f` | Page forward |
+| `ctrl+b` | Page back |
 | `ctrl+g` | Open current prompt in external editor; or dismiss dialog |
-| `Home` / `End` | Navigate within visual line; jump to top/bottom of scroll buffer in alt-screen mode |
+| `ctrl+d` | Exit prompt (no longer queues a message; use `Ctrl+Q` or `Ctrl+Enter` to queue) |
+| `Home` / `End` | Navigate within visual line; jump to top/bottom of scroll buffer |
 | `ctrl+Home` / `ctrl+End` | Jump to text boundaries |
 | `Shift+Tab` | Cycle through modes — (chat) ⟷ (edit); use `!` for shell mode |
 | `Shift+Enter` | Insert newline in prompt (requires kitty keyboard protocol) |
-| `Page Up` / `Page Down` | Scroll in alt-screen mode |
-| `Double-click` | Select word in alt-screen mode |
-| `Triple-click` | Select line in alt-screen mode |
+| `Page Up` / `Page Down` | Scroll |
+| `Double-click` | Select word |
+| `Triple-click` | Select line |
 
 > [!WARNING]
 > Some keyboard shortcuts require specific terminal capabilities:
 > - **Shift+Enter** for newlines requires terminals with kitty keyboard protocol support
 > - **Ctrl+Z** suspend/resume works on Unix platforms only
-> - **Page Up/Down**, **Double/Triple-click** require alt-screen mode support
 > - **Ctrl+Y**, **Ctrl+X Ctrl+E**, and **Ctrl+G** require a terminal editor (set via `$COPILOT_EDITOR`, `$VISUAL`, or `$EDITOR`)
 > - Use `--screen-reader` to enable screen reader optimizations for accessible output
 
@@ -166,10 +164,10 @@ Some commands are covered in depth in later modules (`/mcp` in Module 5, `/skill
 | --- | --- |
 | `/plan [prompt]` | Ask Copilot to create an implementation plan before writing code |
 | `/review [prompt]` | Run a code review agent to analyze changes |
-| `/diff` | Review all changes with syntax highlighting (17 languages) |
+| `/diff` | Review all changes with syntax highlighting (17 languages); supports Home/End and Page Up/Page Down navigation |
 | `/init` | Initialize Copilot instructions and agentic features for a repository |
 | `/tasks` | View and manage background tasks (subagents, shell sessions) |
-| `/rename <name>` | Rename the current session for easy identification |
+| `/rename <name>` | Rename the current session for easy identification; omit name to auto-generate from conversation history |
 | `/theme [show\|set\|list]` | View or configure the terminal color theme |
 | `/terminal-setup` | Configure terminal for multiline input support (shift+enter) |
 | `/lsp` | View configured Language Server Protocol servers |
@@ -178,11 +176,18 @@ Some commands are covered in depth in later modules (`/mcp` in Module 5, `/skill
 | `/changelog` | View the changelog for recent Copilot CLI releases |
 | `/research [prompt]` | Perform deep research with exportable reports |
 | `/chronicle [standup\|tips\|improve]` | ⚠️ **Experimental** — Productivity insights powered by session history |
-| `/copy` | Copy the last response to the system clipboard (v1.0.x) |
-| `/ide` | Connect to an IDE workspace (VS Code, etc.) for diagnostics and diff review (v1.0.x) |
+| `/copy` | Copy the last response to the system clipboard |
+| `/ide` | Connect to an IDE workspace (VS Code, etc.) for diagnostics and diff review |
 | `/restart` | Hot restart the CLI while preserving your session |
 | `/version` | Display CLI version and check for updates |
-| `/streamer-mode` | Toggle streamer mode — hides preview model names and quota details (v1.0.x) |
+| `/streamer-mode` | Toggle streamer mode — hides preview model names and quota details |
+| `/undo` | Undo the last turn and revert file changes |
+| `/rewind` | Open a timeline picker to roll back to any point in conversation history (also via double-Esc) |
+| `/new [prompt]` | Start a fresh conversation (keeps old session backgrounded); optionally provide a first message |
+| `/clear [prompt]` | Abandon the current session entirely; optionally provide a first message for the new session |
+| `/allow-all [on\|off\|show]` | Enable, disable, or check allow-all (YOLO) mode |
+| `/share html` | Export session as a self-contained interactive HTML file |
+| `/mcp auth` | Re-authenticate MCP OAuth servers with account switching support |
 
 > ⚠️ **FEEDBACK**: `/research` and `/chronicle` (experimental) are recent additions. `/chronicle` subcommands (`standup`, `tips`, `improve`) and behavior may change across versions.
 

--- a/docs/workshop/03-instructions.md
+++ b/docs/workshop/03-instructions.md
@@ -59,8 +59,6 @@ This is especially helpful when multiple instruction files interact and you need
 
 ### Disabling Custom Instructions
 
-> ⚠️ **FEEDBACK**: The `--no-custom-instructions` flag and `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` env var are available in **v1.0.x**.
-
 You can completely disable loading of custom instructions from AGENTS.md and related files:
 
 ```bash
@@ -78,7 +76,7 @@ copilot
 
 ### System Message Customization
 
-> ⚠️ **FEEDBACK**: The "customize" mode for system message configuration is available in **v1.0.7**.
+> ⚠️ **FEEDBACK**: The "customize" mode for system message configuration is available since **v1.0.7**.
 
 You can override specific sections of the system prompt using the "customize" mode in configuration. This allows section-level control over the system message without replacing it entirely.
 

--- a/docs/workshop/04-tools.md
+++ b/docs/workshop/04-tools.md
@@ -286,6 +286,9 @@ Deny rules take precedence over allow rules.
 **Expected Outcome:**
 You understand YOLO mode's power and risks.
 
+> [!TIP]
+> Inside an interactive session, use `/allow-all on` to enable, `/allow-all off` to disable, or `/allow-all show` to check the current allow-all mode status.
+
 ### Exercise 6: Configuring Trusted and Accessible Directories
 
 **Goal:** Understand the two separate directory permission layers in Copilot CLI.
@@ -294,7 +297,7 @@ You understand YOLO mode's power and risks.
 >
 > | Layer | Purpose | Scope |
 > |---|---|---|
-> | **Startup trust** (`trusted_folders`) | Skips the "do you trust this folder?" prompt when launching Copilot | Launch-time only |
+> | **Startup trust** (`trustedFolders`) | Skips the "do you trust this folder?" prompt when launching Copilot | Launch-time only |
 > | **Runtime access** (`/add-dir`, `--allow-path`) | Controls which paths the agent can read/write during a session | Session-time only |
 >
 > These are **independent** — trusting a folder does **not** grant runtime file access to it, and vice versa.
@@ -309,7 +312,7 @@ You understand YOLO mode's power and risks.
 
 2. When prompted about trusting the folder:
  - **Yes, proceed** — Trust for this session only
- - **Yes, and remember** — Permanently add to `trusted_folders`
+ - **Yes, and remember** — Permanently add to `trustedFolders`
  - **No, exit** — Don't trust
 
 3. Select **Yes, proceed** for now.
@@ -318,13 +321,13 @@ You understand YOLO mode's power and risks.
  ```bash
  cat ~/.copilot/config.json
  ```
- Notice that `trusted_folders` was **not** updated (you chose session-only trust).
+ Notice that `trustedFolders` was **not** updated (you chose session-only trust).
 
 5. To permanently skip the prompt for specific directories, add them to your config:
  ```bash
  # Edit config.json to add:
  {
- "trusted_folders": [
+ "trustedFolders": [
  "/home/user/projects",
  "/home/user/copilot-workshop"
  ]
@@ -338,7 +341,7 @@ You understand YOLO mode's power and risks.
  ```
  /list-dirs
  ```
- You'll see only the **working directory** and `/tmp` — not the `trusted_folders` entries.
+ You'll see only the **working directory** and `/tmp` — not the `trustedFolders` entries.
 
 7. Grant runtime access to an additional directory:
  > Note: Create the directory first (e.g., `mkdir -p /tmp/safe-dir`).
@@ -354,7 +357,7 @@ You understand YOLO mode's power and risks.
  ```
 
 **Expected Outcome:**
-You understand that `trusted_folders` controls the **startup trust prompt**, while `/add-dir`, `/list-dirs`, and `--allow-path` control **runtime file access** — and that these are two independent permission layers.
+You understand that `trustedFolders` controls the **startup trust prompt**, while `/add-dir`, `/list-dirs`, and `--allow-path` control **runtime file access** — and that these are two independent permission layers.
 
 ### Exercise 7: Creating a Safe Automation Script
 
@@ -433,7 +436,7 @@ Safe, repeatable automation with explicit permissions.
 # Allow specific MCP tool
 --allow-tool 'MyMCP(my_tool)'
 
-# URL access matching (v1.0.x)
+# URL access matching
 --allow-tool 'url(https://github.com)'
 --allow-tool 'url(https://*.github.com)'
 
@@ -442,8 +445,6 @@ Safe, repeatable automation with explicit permissions.
 ```
 
 ### URL Permissions
-
-> ⚠️ **FEEDBACK**: URL permission flags (`--allow-url`, `--deny-url`, `--allow-all-urls`, `--disallow-temp-dir`) are available in **v1.0.x**.
 
 Copilot CLI provides granular URL access control. All URL permissions are protocol-aware — approving `https://example.com` does NOT allow `http://example.com`.
 
@@ -486,8 +487,6 @@ copilot --disallow-temp-dir
 
 ### Secret Environment Variables
 
-> ⚠️ **FEEDBACK**: `--secret-env-vars` is available in **v1.0.x**.
-
 Strip sensitive environment variable values from shell/MCP server environments and redact them from output:
 
 ```bash
@@ -495,8 +494,6 @@ copilot --secret-env-vars MY_API_KEY DATABASE_PASSWORD
 ```
 
 ### Autonomous Mode (No User Questions)
-
-> ⚠️ **FEEDBACK**: `--no-ask-user` is available in **v1.0.x**.
 
 Disable the `ask_user` tool so the agent works autonomously without asking questions. Useful for CI/CD pipelines where no human is available to respond:
 

--- a/docs/workshop/05-mcps.md
+++ b/docs/workshop/05-mcps.md
@@ -95,8 +95,6 @@ MCP servers defined in `devcontainer.json` are merged with your personal `~/.cop
 
 ### Built-in GitHub MCP Server Controls
 
-> ⚠️ **FEEDBACK**: GitHub MCP server control flags (`--add-github-mcp-tool`, `--add-github-mcp-toolset`, `--enable-all-github-mcp-tools`, `--disable-builtin-mcps`, `--disable-mcp-server`) are available in **v1.0.x**.
-
 Copilot CLI includes a built-in GitHub MCP server with a default subset of tools. You can customize which tools are available:
 
 ```bash
@@ -569,6 +567,10 @@ MCP server names (the keys in `"mcpServers"`) support dots (`.`), slashes (`/`),
 - ✅ Remote servers connect to external services
 - ✅ `/mcp` commands manage servers without editing files
 - ✅ `/mcp reload` reloads configuration without restarting
+- ✅ `/mcp auth` re-authenticates MCP OAuth servers with account switching support
+- ✅ MCP OAuth supports device code flow (RFC 8628) for headless/CI environments
+- ✅ MCP tool calls display tool name and parameter summary in the timeline
+- ✅ MCP servers can request LLM inference (sampling) with user approval
 - ✅ Tilde (`~`) expansion works in `cwd` paths
 - ✅ MCP server errors surface in session output for easier debugging
 - ✅ Giant single-line MCP tool results are now truncated correctly

--- a/docs/workshop/06-skills.md
+++ b/docs/workshop/06-skills.md
@@ -277,7 +277,7 @@ Skill uses example files to generate framework-appropriate tests.
 **Goal:** Create skills that work across all your projects.
 
 > [!NOTE]
-> In Exercises 1-2 we created skills under `.github/skills/` — those are **project skills**, scoped to a single repository and shared with your team via Git. In this exercise we use `~/.copilot/skills/` — these are **personal skills**, stored in your home directory and available in every project you open with Copilot CLI. Use project skills for repo-specific tasks; use personal skills for workflows you want everywhere.
+> In Exercises 1-2 we created skills under `.github/skills/` — those are **project skills**, scoped to a single repository and shared with your team via Git. In this exercise we use `~/.copilot/skills/` — these are **personal skills**, stored in your home directory and available in every project you open with Copilot CLI. You can also use `~/.agents/skills/` as a personal skill discovery directory (shared with the VS Code extension). Use project skills for repo-specific tasks; use personal skills for workflows you want everywhere.
 
 **Steps:**
 
@@ -615,6 +615,7 @@ license: MIT # Optional: License identifier
 |----------|-------|----------|
 | `.github/skills/` | Project | Higher |
 | `~/.copilot/skills/` | Personal | Lower |
+| `~/.agents/skills/` | Personal (shared with VS Code) | Lower |
 | `~/.claude/skills/` | Personal (legacy) | Lower |
 
 ## Summary

--- a/docs/workshop/07-plugins.md
+++ b/docs/workshop/07-plugins.md
@@ -80,7 +80,7 @@ Key capabilities:
 6. **Remote sources** - GitHub repos and git URLs referenced in `marketplace.json`
 
 > [!NOTE]
-> Two marketplaces are included by default and do not need to be added: `copilot-plugins` (github/copilot-plugins) and `awesome-copilot` (github/awesome-copilot).
+> Two marketplaces are included by default and do not need to be added: `copilot-plugins` (github/copilot-plugins) and `awesome-copilot` (github/awesome-copilot). Additional marketplaces can be configured via the `extraKnownMarketplaces` repository setting.
 
 ## Hands-On Exercises
 
@@ -473,7 +473,7 @@ You can find, evaluate, and contribute to the plugin ecosystem.
 # Install from a GitHub repository
 copilot plugin install owner/repo
 
-# Install from a subdirectory within a repo (v1.0.x)
+# Install from a subdirectory within a repo
 copilot plugin install owner/repo:plugins/my-plugin
 
 # Install from a git URL
@@ -481,8 +481,6 @@ copilot plugin install https://github.com/owner/my-plugin.git
 ```
 
 ### From a Local Directory
-
-> ⚠️ **FEEDBACK**: `--plugin-dir` is available in **v1.0.x**.
 
 Load a plugin from a local directory without installing it — useful for plugin development:
 
@@ -558,8 +556,8 @@ copilot --plugin-dir ./plugin-a --plugin-dir ./plugin-b
 - ✅ Community MCP servers add diverse capabilities
 - ✅ You can create custom plugins for specific needs
 - ✅ Always review plugins for security before installation
-- ✅ `--plugin-dir` loads local plugins for development (v1.0.x)
-- ✅ `owner/repo:path` installs from repository subdirectories (v1.0.x)
+- ✅ `--plugin-dir` loads local plugins for development
+- ✅ `owner/repo:path` installs from repository subdirectories
 - ✅ `/plugin install` and `/plugin marketplace add` now support local paths with spaces
 - ✅ `/plugin install` hot-loads agents and skills — no CLI restart needed
 - ✅ Extensions (experimental) — runtime tools via `@github/copilot-sdk` (v1.0.3+)

--- a/docs/workshop/08-custom-agents.md
+++ b/docs/workshop/08-custom-agents.md
@@ -54,7 +54,7 @@ You can create agent files manually, or use the **`/agent`** slash command in in
 5. **Restart the CLI** to load your new custom agent.
 
 > [!NOTE]
-> Manually created `.agent.md` files require a CLI restart to take effect. However, agents installed via `/plugin install` are **hot-loaded** and available immediately without restarting. See [Module 8](08-plugins.md).
+> Manually created `.agent.md` files require a CLI restart to take effect. However, agents installed via `/plugin install` are **hot-loaded** and available immediately without restarting. See [Module 7](07-plugins.md).
 
 ### Invoking Agents
 
@@ -529,9 +529,9 @@ Agent performs analysis without modification capabilities.
 
 > **Note:** Enterprise and organization-level agents are configured by admins in a `.github-private` repository. See the [GitHub Docs](https://docs.github.com/en/copilot/how-tos/administer-copilot/manage-for-organization/prepare-for-custom-agents) for details.
 
-> ⚠️ **FEEDBACK**: The `custom_agents.default_local_only` config option (v1.0.x) allows you to default to only local custom agents, skipping remote org/enterprise agents. Set it in `~/.copilot/config.json`:
+> ⚠️ **FEEDBACK**: The `customAgents.defaultLocalOnly` config option allows you to default to only local custom agents, skipping remote org/enterprise agents. Set it in `~/.copilot/config.json`:
 > ```json
-> { "custom_agents": { "default_local_only": true } }
+> { "customAgents": { "defaultLocalOnly": true } }
 > ```
 
 **Expected Outcome:**

--- a/docs/workshop/09-hooks.md
+++ b/docs/workshop/09-hooks.md
@@ -34,10 +34,12 @@ User Prompt → Session Start → Pre-Tool → Tool Execution → Post-Tool → 
 | `sessionEnd` | Session ends | Cleanup, metrics |
 | `userPromptSubmitted` | User sends prompt | Audit, filtering |
 | `preToolUse` | Before tool execution | Permission control, validation |
-| `postToolUse` | After tool execution | Logging, verification |
+| `postToolUse` | After successful tool execution | Logging, verification |
+| `postToolUseFailure` | After tool execution fails | Error handling, retry logic |
 | `errorOccurred` | Error happens | Error handling, alerts |
 | `preCompact` | Before context compaction | Pre-compaction tasks, state saving |
 | `subagentStart` | Sub-agent is spawned | Context injection, logging |
+| `permissionRequest` | Tool permission requested | Programmatic approve/deny of tool permissions |
 
 ### Hook Locations
 
@@ -483,7 +485,7 @@ All tool executions are logged with results:
 
 **Goal:** Capture and respond to internal Copilot errors.
 
-> **Note:** The `errorOccurred` hook fires for internal Copilot errors (network failures, API errors, etc.), not for tool failures. Tool failures are handled gracefully via `postToolUse` with `resultType: "error"`.
+> **Note:** The `errorOccurred` hook fires for internal Copilot errors (network failures, API errors, etc.), not for tool failures. Tool failures are handled by the `postToolUseFailure` hook. The `postToolUse` hook fires only after successful tool calls.
 
 **Steps:**
 
@@ -736,7 +738,9 @@ All tool executions are logged with results:
 
 - ✅ Hooks execute at key points in agent lifecycle
 - ✅ `preToolUse` enables security guardrails
-- ✅ `postToolUse` allows verification and logging
+- ✅ `postToolUse` allows verification and logging (fires only on successful tool calls)
+- ✅ `postToolUseFailure` handles tool errors separately
+- ✅ `permissionRequest` hook enables programmatic approve/deny of tool permissions
 - ✅ Session hooks enable auditing
 - ✅ Error hooks support monitoring integration
 - ✅ Hooks must return JSON for permission decisions
@@ -745,6 +749,7 @@ All tool executions are logged with results:
 - ✅ `disableAllHooks` flag disables all hooks (v1.0.4+)
 - ✅ Hook `ask` permission decision prompts user for confirmation (v1.0.4+)
 - ✅ Cross-platform hook configs work across VS Code, Claude Code, and CLI (v1.0.6+)
+- ✅ Hooks can also be defined in `settings.json`, `settings.local.json`, and `config.json`
 
 ## Next Steps
 

--- a/docs/workshop/10-context.md
+++ b/docs/workshop/10-context.md
@@ -52,7 +52,7 @@ Context is everything Copilot "remembers" during a session:
 > **Model auto-migration:** Users previously on older models are automatically migrated to the current default model on startup.
 
 > [!NOTE]
-> Use `/model` to select a model and `/context` to see context window usage. The model list changes frequently; available models at the time of writing include: claude-sonnet-4.6, claude-opus-4.6, claude-opus-4.6-fast, gpt-5.4, gpt-5.2, gpt-4.1, gemini-3-pro-preview, and others.
+> Use `/model` to select a model and `/context` to see context window usage. The model list changes frequently; available models at the time of writing include: claude-sonnet-4.6, claude-opus-4.6, claude-opus-4.6-fast, gpt-5.4, gpt-5.2, gpt-4.1, and others.
 >
 > Model availability may vary by Copilot subscription tier.
 
@@ -98,8 +98,6 @@ What's the status of #150 and are there related PRs?
 ```
 
 When you type `#`, matching issues and PRs from the current repository are displayed below the prompt box. Use the arrow keys to select and press Tab to complete.
-
-> ⚠️ **FEEDBACK**: The `#` reference shortcut requires Copilot CLI v1.0.x. Verify availability with `copilot --version`.
 
 ### Auto-Compaction
 
@@ -467,7 +465,8 @@ Systematic workflow keeps context under control.
 | `/context` | Show visual overview of token usage |
 | `/usage` | Show session stats (requests, duration, lines edited, token usage per model) |
 | `/compact` | Compress session history |
-| `/clear` | Clear all context (start fresh) |
+| `/clear` | Abandon session and start fresh (session is discarded) |
+| `/new` | Start new conversation (old session stays backgrounded) |
 | `/cwd` or `/cd` | Change working directory (affects context scope) |
 | `/add-dir` | Add directory to accessible scope (persists across `/clear` and `/resume`) |
 | `@path/to/file` | Include specific file contents in your prompt |
@@ -487,7 +486,8 @@ Systematic workflow keeps context under control.
 
 | Strategy | When to Use |
 |----------|-------------|
-| `/clear` | Switching to unrelated topic |
+| `/clear` | Abandoning session entirely |
+| `/new` | Starting new topic but keeping old session accessible |
 | `/compact` | Long session, need to continue |
 | Explore agent | Codebase overview without context cost |
 | `@path/to/file` | Include specific files without broad reads |
@@ -519,7 +519,7 @@ Systematic workflow keeps context under control.
 
 - ✅ Context is limited - monitor with `/context` and `/usage`
 - ✅ `/compact` compresses while preserving key info
-- ✅ `/clear` resets for topic changes
+- ✅ `/clear` abandons the session; `/new` starts fresh while keeping the old session backgrounded
 - ✅ Auto-compaction triggers at ~95% capacity
 - ✅ Use `@path/to/file` to include specific files in prompts
 - ✅ Use `#<number>` to pull GitHub issues, PRs, or discussions into context

--- a/docs/workshop/11-sessions.md
+++ b/docs/workshop/11-sessions.md
@@ -167,12 +167,17 @@ The `--resume` flag restores your previous session state.
    /cwd
    ```
 
-6. **Clear conversation history:**
+6. **Clear conversation history (abandons session):**
    ```
    /clear
    ```
 
-7. Verify context is cleared:
+7. Or start a new conversation (keeps old session backgrounded):
+   ```
+   /new
+   ```
+
+8. Verify context is cleared:
    ```
    What was I just working on?
    ```
@@ -276,11 +281,11 @@ You can control Copilot's file access scope.
 
 | Scenario | Action |
 | --- | --- |
-| Switching to unrelated task | `/clear` |
-| Confused responses | `/clear` |
-| Context limit approaching | `/compact` first, then `/clear` if needed |
+| Switching to unrelated task | `/new` (keeps old session) or `/clear` (abandons) |
+| Confused responses | `/new` |
+| Context limit approaching | `/compact` first, then `/new` if needed |
 | Sensitive info discussed | `/clear` and `/exit` |
-| Session becomes slow | `/clear` |
+| Session becomes slow | `/new` |
 
 **Expected Outcome:**
 You know when clearing context improves your workflow.
@@ -366,10 +371,14 @@ Session transcript saved for future reference or sharing.
 | `/cwd` | Show/change directory | `/cwd ~/project` |
 | `/add-dir` | Add accessible directory | `/add-dir /tmp` |
 | `/list-dirs` | List accessible directories | `/list-dirs` |
-| `/clear` | Clear conversation history | `/clear` |
+| `/clear` | Abandon session and start fresh | `/clear` |
+| `/new [prompt]` | Start new conversation (old session stays backgrounded) | `/new` |
 | `/exit` | End session | `/exit` |
 | `/share` | Export session transcript (interactive alternative to `--share` flag) | `/share` |
+| `/share html` | Export session as self-contained interactive HTML file | `/share html` |
 | `/model` | Switch AI model | `/model gpt-4` |
+| `/undo` | Undo last turn and revert file changes | `/undo` |
+| `/rewind` | Roll back to any point in conversation history (also via double-Esc) | `/rewind` |
 
 ## Command Line Flags
 
@@ -384,10 +393,13 @@ Session transcript saved for future reference or sharing.
 
 - ✅ Sessions maintain conversation history and context
 - ✅ Use `--resume` to continue previous sessions
-- ✅ `/clear` resets context without exiting
-- ✅ `/cwd` and `/add-dir` control file access scope
+- ✅ `/clear` abandons the session; `/new` starts fresh while keeping the old session backgrounded
+- ✅ `/undo` reverts the last turn and its file changes
+- ✅ `/rewind` (or double-Esc) opens a timeline picker for rolling back to any conversation point
+- ✅ `/rename` auto-generates a session name from conversation history when called without arguments
+- ✅ `/cwd` and `/add-dir` control file access scope; `/cd` keeps a separate working directory per session
 - ✅ Run multiple sessions in different terminals
-- ✅ Export sessions with `--share` for documentation
+- ✅ Export sessions with `--share` for documentation or `/share html` for interactive HTML
 
 ## Next Steps
 

--- a/docs/workshop/12-advanced.md
+++ b/docs/workshop/12-advanced.md
@@ -36,9 +36,10 @@ Session Overrides (flags)
 | `~/.copilot/config.json` | User settings |
 | `~/.copilot/mcp-config.json` | MCP servers |
 | `~/.copilot/skills/` | Personal skills |
+| `~/.agents/skills/` | Personal skill discovery directory (shared with VS Code extension) |
 | `.github/` | Repository config |
 
-### New Commands & Features (v1.0.3–v1.0.7)
+### New Commands & Features (v1.0.3–v1.0.16)
 
 Several commands and features have been added since v1.0.2:
 
@@ -67,6 +68,18 @@ The `read_agent` output now includes inbound messages that triggered each turn i
 #### `/experimental` Toggle
 
 > Since v1.0.5, toggling experimental mode with `/experimental on|off` automatically restarts the CLI to apply changes immediately. No manual restart needed.
+
+#### Monorepo Support
+
+Custom instructions, MCP servers, skills, and agents are now discovered at every directory level from the working directory up to the git root, enabling full monorepo support.
+
+#### `--effort` Shorthand
+
+Use `--effort` as a shorthand alias for `--reasoning-effort` to control model reasoning level.
+
+#### `--resume` Enhancements
+
+`--resume` now accepts a task ID in addition to a session ID.
 
 ## Hands-On Exercises
 
@@ -270,9 +283,7 @@ Copilot CLI integrated into automated workflows.
  copilot --additional-mcp-config ./custom-mcp.json
  ```
 
-5. **Output and streaming control (v1.0.x):**
-
- > ⚠️ **FEEDBACK**: `--output-format`, `--stream`, `--no-color`, and `--acp` are available in **v1.0.x**.
+5. **Output and streaming control:**
 
  ```bash
  # JSON output for scripting (one JSON object per line)
@@ -379,9 +390,7 @@ Full command-line control over Copilot behavior.
  # Now you'll be prompted for approval on each action
  ```
 
-7. **Limit autopilot continuation rounds (v1.0.x):**
-
- > ⚠️ **FEEDBACK**: `--max-autopilot-continues` is available in **v1.0.x**.
+7. **Limit autopilot continuation rounds:**
 
  ```bash
  # Limit to 10 continuation rounds (default: unlimited)
@@ -765,16 +774,13 @@ Language server timeouts are configured for your environment, eliminating timeou
 
  ```json
  {
- "trusted_folders": [
+ "trustedFolders": [
  "/home/user/projects",
  "/home/user/work"
  ],
- "default_model": "gpt-4.1",
+ "model": "gpt-4.1",
  "theme": "dark",
- "editor": "code",
- "shell": "bash",
- "telemetry": true,
- "auto_update": true
+ "autoUpdate": true
  }
  ```
 
@@ -782,7 +788,7 @@ Language server timeouts are configured for your environment, eliminating timeou
 
  ```bash
  # Using jq to update config
- jq '.trusted_folders += ["/new/path"]' ~/.copilot/config.json > tmp.json
+ jq '.trustedFolders += ["/new/path"]' ~/.copilot/config.json > tmp.json
  mv tmp.json ~/.copilot/config.json
  ```
 
@@ -790,15 +796,13 @@ Language server timeouts are configured for your environment, eliminating timeou
 
  ```json
  {
- "web_fetch": {
- "allowed_urls": [
+ "allowedUrls": [
  "https://api.github.com/*",
  "https://docs.github.com/*"
  ],
- "denied_urls": [
+ "deniedUrls": [
  "https://evil.com/*"
  ]
- }
  }
  ```
 
@@ -1129,67 +1133,74 @@ You can run deep-research workflows and extract insights from your session histo
 | `~/.copilot/mcp-config.json` | MCP servers | Base |
 | `~/.copilot/lsp.json` | LSP timeout configuration | |
 | `~/.copilot/skills/` | Personal skills | Base |
+| `~/.agents/skills/` | Personal skill discovery (shared with VS Code) | v1.0.11+ |
 | `.github/copilot-instructions.md` | Repository instructions | Base |
 
 ### Key Command-Line Flags
 
-| Flag | Description | Version |
-| ------ | ------------- | --------- |
-| `-p, --prompt` | Programmatic mode prompt | Base |
-| `-i, --interactive` | Interactive mode with auto-executed prompt | v1.0.x |
-| `--model` | Select AI model | Base |
-| `--resume` | Resume last session | Base |
-| `--yolo` / `--allow-all` | Allow all tools, paths, and URLs | Base |
-| `--allow-tool` / `--deny-tool` | Allow/deny specific tools | Base |
-| `--allow-url` / `--deny-url` | Allow/deny specific URLs | v1.0.x |
-| `--silent` | Suppress output | Base |
-| `--output-format` | Output as `text` or `json` (JSONL) | v1.0.x |
-| `--share PATH` | Export to markdown | Base |
-| `--share-gist` | Export to Gist | Base |
-| `--additional-mcp-config` | Add MCP config | Base |
-| `--autopilot` | Enable autonomous multi-step execution | |
-| `--max-autopilot-continues` | Limit autopilot continuation rounds | v1.0.x |
-| `--no-ask-user` | Disable agent questions (fully autonomous) | v1.0.x |
-| `--acp` | Start as Agent Client Protocol server | v1.0.x |
-| `--stream` | Enable/disable streaming (on/off) | v1.0.x |
-| `--bash-env` | Source BASH_ENV in shell sessions | |
-| `--experimental` | Enable experimental features | |
-| `--mouse` / `--no-mouse` | Alt-screen mouse behavior | |
-| `--secret-env-vars` | Redact env var values | v1.0.x |
-| `--no-custom-instructions` | Disable AGENTS.md loading | v1.0.x |
-| `--screen-reader` | Screen reader optimizations | v1.0.x |
-| `--no-color` | Disable color output | v1.0.x |
+| Flag | Description |
+| ------ | ------------- |
+| `-p, --prompt` | Programmatic mode prompt |
+| `-i, --interactive` | Interactive mode with auto-executed prompt |
+| `--model` | Select AI model |
+| `--resume` | Resume last session (accepts session ID or task ID) |
+| `--yolo` / `--allow-all` | Allow all tools, paths, and URLs |
+| `--allow-tool` / `--deny-tool` | Allow/deny specific tools |
+| `--allow-url` / `--deny-url` | Allow/deny specific URLs |
+| `--silent` | Suppress output |
+| `--output-format` | Output as `text` or `json` (JSONL) |
+| `--share PATH` | Export to markdown |
+| `--share-gist` | Export to Gist |
+| `--additional-mcp-config` | Add MCP config |
+| `--autopilot` | Enable autonomous multi-step execution |
+| `--max-autopilot-continues` | Limit autopilot continuation rounds |
+| `--no-ask-user` | Disable agent questions (fully autonomous) |
+| `--acp` | Start as Agent Client Protocol server |
+| `--stream` | Enable/disable streaming (on/off) |
+| `--bash-env` | Source BASH_ENV in shell sessions |
+| `--experimental` | Enable experimental features |
+| `--mouse` / `--no-mouse` | Mouse behavior |
+| `--effort` | Shorthand for `--reasoning-effort` |
+| `--secret-env-vars` | Redact env var values |
+| `--no-custom-instructions` | Disable AGENTS.md loading |
+| `--screen-reader` | Screen reader optimizations |
+| `--no-color` | Disable color output |
 
 ### Slash Commands
 
-| Command | Description | Version |
-| --------- | ------------- | --------- |
-| `/help` | Show all available commands | Base |
-| `/clear` | Clear session context | Base |
-| `/context` | View token usage | Base |
-| `/compact` | Compress session history | Base |
-| `/plan` | Create implementation plan | Base |
-| `/review` | Run code review agent | Base |
-| `/delegate` | Hand off to cloud agent | Base |
-| `/fleet` | Launch parallel sub-agents for complex tasks | |
-| `/autopilot on\|off` | Toggle autopilot mode | |
-| `/research` | Launch deep-research workflow with exportable reports | |
-| `/chronicle` | Session-history insights (standup, tips, improve) — experimental | |
-| `/diagnose` | Show diagnostic summary of session and environment | |
-| `/copy` | Copy last response to clipboard | v1.0.x |
-| `/ide` | Connect to IDE workspace | v1.0.x |
-| `/streamer-mode` | Toggle streamer mode | v1.0.x |
-| `/mcp` | Manage MCP servers | Base |
+| Command | Description |
+| --------- | ------------- |
+| `/help` | Show all available commands |
+| `/clear` | Abandon session and start fresh |
+| `/new [prompt]` | Start new conversation (old session backgrounded) |
+| `/context` | View token usage |
+| `/compact` | Compress session history |
+| `/plan` | Create implementation plan |
+| `/review` | Run code review agent |
+| `/delegate` | Hand off to cloud agent |
+| `/fleet` | Launch parallel sub-agents for complex tasks |
+| `/autopilot on\|off` | Toggle autopilot mode |
+| `/research` | Launch deep-research workflow with exportable reports |
+| `/chronicle` | Session-history insights (standup, tips, improve) — experimental |
+| `/diagnose` | Show diagnostic summary of session and environment |
+| `/undo` | Undo last turn and revert file changes |
+| `/rewind` | Timeline picker to roll back to any point (also double-Esc) |
+| `/copy` | Copy last response to clipboard |
+| `/ide` | Connect to IDE workspace |
+| `/streamer-mode` | Toggle streamer mode |
+| `/mcp` | Manage MCP servers |
+| `/mcp auth` | Re-authenticate MCP OAuth servers |
+| `/share html` | Export session as interactive HTML |
+| `/allow-all [on\|off\|show]` | Enable, disable, or check allow-all mode |
 
 ### Shell Mode Access
 
 > **Changed**: Shell mode removed from Shift+Tab cycle
 
-| Method | Description | Version |
-| -------- | ------------- | --------- |
-| `!` | Direct access to shell mode | |
-| `Shift+Tab` | Cycle (chat) ⟷ (edit) only | |
-| `Shift+Tab` | Cycle (chat) → (edit) → (shell) | Deprecated |
+| Method | Description |
+| -------- | ------------- |
+| `!` | Direct access to shell mode |
+| `Shift+Tab` | Cycle (chat) ⟷ (edit) only |
 
 ### Useful Aliases
 
@@ -1220,7 +1231,7 @@ alias cop-resume='copilot --resume'
 - ✅ **Autopilot mode** enables autonomous multi-step task execution
 - ✅ **Fleet command** parallelizes complex tasks with orchestrator validation
 - ✅ **--bash-env** sources custom environment for shell sessions
-- ✅ **--experimental** enables alt-screen mode by default
+- ✅ **--experimental** enables experimental features
 - ✅ **Configurable status line** displays dynamic session info via custom shell scripts
 - ✅ **Environment loading indicator** shows skills, MCPs, and plugins being loaded at startup
 - ✅ **Status line responsive layout** auto-switches to two-line layout on narrow terminals
@@ -1228,14 +1239,16 @@ alias cop-resume='copilot --resume'
 - ✅ **`/research` command** for deep-research workflows with exportable reports
 - ✅ **`--disable-parallel-tools-execution` removed** — parallel tool execution is now always enabled
 - ✅ **`/chronicle` command** (experimental) for session-history insights: standup, tips, improve
-- ✅ **`--mouse`/`--no-mouse` flag** controls alt-screen mouse behavior
+- ✅ **`--mouse`/`--no-mouse` flag** controls mouse behavior
+- ✅ **`--effort` flag** shorthand for `--reasoning-effort`
+- ✅ **Monorepo support** discovers instructions, MCPs, skills, and agents from cwd to git root
 - ✅ **`/diagnose` command** for troubleshooting session and environment issues
-- ✅ **`--max-autopilot-continues`** limits autopilot continuation rounds (v1.0.x)
-- ✅ **`--no-ask-user`** enables fully autonomous operation without questions (v1.0.x)
-- ✅ **`--acp`** starts Agent Client Protocol server (v1.0.x)
-- ✅ **`--output-format json`** enables JSONL output for scripting (v1.0.x)
-- ✅ **`--stream`** controls streaming mode (v1.0.x)
-- ✅ **`-i, --interactive`** starts interactive mode with auto-executed prompt (v1.0.x)
+- ✅ **`--max-autopilot-continues`** limits autopilot continuation rounds
+- ✅ **`--no-ask-user`** enables fully autonomous operation without questions
+- ✅ **`--acp`** starts Agent Client Protocol server
+- ✅ **`--output-format json`** enables JSONL output for scripting
+- ✅ **`--stream`** controls streaming mode
+- ✅ **`-i, --interactive`** starts interactive mode with auto-executed prompt
 - ✅ **LSP configuration** controls language server timeouts; default request timeout is 90s
 - ✅ **Shell mode access** via `!` command
 - ✅ config.json and lsp.json persist preferences

--- a/docs/workshop/13-configuration.md
+++ b/docs/workshop/13-configuration.md
@@ -27,40 +27,37 @@ copilot --config-dir /path/to/custom/config
 
 ### Configuration Options Reference
 
-> ⚠️ **FEEDBACK**: Many config options below are available in **v1.0.x**. Run `copilot help config` to verify available options for your version.
-
 All options below are set in ~/.copilot/config.json:
 
 ```json
 {
   "model": "claude-sonnet-4.6",
   "theme": "auto",
-  "alt_screen": false,
   "mouse": true,
   "banner": "once",
   "beep": true,
   "stream": true,
-  "auto_update": true,
-  "bash_env": false,
+  "autoUpdate": true,
+  "bashEnv": false,
   "experimental": false,
-  "compact_paste": true,
-  "copy_on_select": false,
-  "render_markdown": true,
-  "screen_reader": false,
-  "streamer_mode": false,
-  "include_coauthor": true,
-  "update_terminal_title": true,
-  "log_level": "default",
+  "compactPaste": true,
+  "copyOnSelect": false,
+  "renderMarkdown": true,
+  "screenReader": false,
+  "streamerMode": false,
+  "includeCoauthor": true,
+  "updateTerminalTitle": true,
+  "logLevel": "default",
   "ide": {
-    "auto_connect": true,
-    "open_diff_on_edit": true
+    "autoConnect": true,
+    "openDiffOnEdit": true
   },
-  "custom_agents": {
-    "default_local_only": false
+  "customAgents": {
+    "defaultLocalOnly": false
   },
-  "trusted_folders": [],
-  "allowed_urls": [],
-  "denied_urls": [],
+  "trustedFolders": [],
+  "allowedUrls": [],
+  "deniedUrls": [],
   "companyAnnouncements": []
 }
 ```
@@ -69,28 +66,27 @@ All options below are set in ~/.copilot/config.json:
 |--------|------|---------|-------------|
 | `model` | string | (varies) | AI model to use; changeable via `/model` or `--model` |
 | `theme` | string | `"auto"` | Color theme: `"auto"`, `"dark"`, or `"light"` |
-| `alt_screen` | bool | `false` | Use terminal alternate screen buffer |
-| `mouse` | bool | `true` | Mouse support in alt-screen mode |
+| `mouse` | bool | `true` | Mouse support |
 | `banner` | string | `"once"` | Startup banner: `"always"`, `"never"`, or `"once"` |
 | `beep` | bool | `true` | Terminal beep when user attention is required |
 | `stream` | bool | `true` | Enable response streaming |
-| `auto_update` | bool | `true` | Auto-download CLI updates (disabled in CI by default) |
-| `bash_env` | bool | `false` | Source BASH_ENV in shell sessions |
+| `autoUpdate` | bool | `true` | Auto-download CLI updates (disabled in CI by default) |
+| `bashEnv` | bool | `false` | Source BASH_ENV in shell sessions |
 | `experimental` | bool | `false` | Enable experimental features |
-| `compact_paste` | bool | `true` | Collapse large pasted content (>10 lines) into compact tokens |
-| `copy_on_select` | bool | macOS: `true`, else: `false` | Auto-copy text selection to clipboard in alt-screen |
-| `render_markdown` | bool | `true` | Render markdown formatting in terminal output |
-| `screen_reader` | bool | `false` | Enable screen reader optimizations |
-| `streamer_mode` | bool | `false` | Hide preview model names and quota details (for streaming/screen sharing) |
-| `include_coauthor` | bool | `true` | Instruct agent to add Co-authored-by trailer to git commits |
-| `update_terminal_title` | bool | `true` | Show current intent in terminal title bar |
-| `log_level` | string | `"default"` | Log level: `"none"`, `"error"`, `"warning"`, `"info"`, `"debug"`, `"all"` |
-| `ide.auto_connect` | bool | `true` | Auto-connect to IDE workspace on startup |
-| `ide.open_diff_on_edit` | bool | `true` | Open file edit diffs in connected IDE for approval |
-| `custom_agents.default_local_only` | bool | `false` | Default to local agents only (skip remote org/enterprise agents) |
-| `trusted_folders` | array | `[]` | Folders granted read/execute permission |
-| `allowed_urls` | array | `[]` | URLs/domains allowed without prompting (supports wildcards like `*.github.com`) |
-| `denied_urls` | array | `[]` | URLs/domains denied access (takes precedence over allowed) |
+| `compactPaste` | bool | `true` | Collapse large pasted content (>10 lines) into compact tokens |
+| `copyOnSelect` | bool | macOS: `true`, else: `false` | Auto-copy text selection to clipboard |
+| `renderMarkdown` | bool | `true` | Render markdown formatting in terminal output |
+| `screenReader` | bool | `false` | Enable screen reader optimizations |
+| `streamerMode` | bool | `false` | Hide preview model names and quota details (for streaming/screen sharing) |
+| `includeCoauthor` | bool | `true` | Instruct agent to add Co-authored-by trailer to git commits |
+| `updateTerminalTitle` | bool | `true` | Show current intent in terminal title bar |
+| `logLevel` | string | `"default"` | Log level: `"none"`, `"error"`, `"warning"`, `"info"`, `"debug"`, `"all"` |
+| `ide.autoConnect` | bool | `true` | Auto-connect to IDE workspace on startup |
+| `ide.openDiffOnEdit` | bool | `true` | Open file edit diffs in connected IDE for approval |
+| `customAgents.defaultLocalOnly` | bool | `false` | Default to local agents only (skip remote org/enterprise agents) |
+| `trustedFolders` | array | `[]` | Folders granted read/execute permission |
+| `allowedUrls` | array | `[]` | URLs/domains allowed without prompting (supports wildcards like `*.github.com`) |
+| `deniedUrls` | array | `[]` | URLs/domains denied access (takes precedence over allowed) |
 | `companyAnnouncements` | array | `[]` | Custom startup messages (one randomly selected per session) |
 | `mergeStrategy` | string | `"merge"` | Git merge strategy for PR operations (renamed from `merge_strategy` in v1.0.3) |
 
@@ -168,7 +164,6 @@ All options below are set in ~/.copilot/config.json:
 | `--banner` | Show startup banner |
 | `--no-color` | Disable color output |
 | `--no-auto-update` | Disable auto-update |
-| `--alt-screen [on\|off]` | Toggle alternate screen buffer |
 | `--mouse [on\|off]` | Toggle mouse support |
 | `--bash-env [on\|off]` | Toggle BASH_ENV support |
 | `--experimental` / `--no-experimental` | Toggle experimental features |
@@ -195,11 +190,11 @@ All options below are set in ~/.copilot/config.json:
    copilot help config
    ```
 
-3. Modify a setting -- enable alt-screen mode:
+3. Modify a setting -- enable mouse mode:
 
    ```json
    {
-     "alt_screen": true
+     "mouse": true
    }
    ```
 
@@ -209,7 +204,6 @@ All options below are set in ~/.copilot/config.json:
 
    ```bash
    # These flags update config.json automatically
-   copilot --alt-screen on
    copilot --mouse off
    copilot --bash-env on
    ```
@@ -286,16 +280,16 @@ You can control Copilot behavior via environment variables and understand their 
    ```json
    {
      "ide": {
-       "auto_connect": true,
-       "open_diff_on_edit": true
+       "autoConnect": true,
+       "openDiffOnEdit": true
      }
    }
    ```
 
-   - `auto_connect: false` prevents auto-connecting to IDEs on startup
-   - `open_diff_on_edit: false` shows file diffs in terminal only, not in IDE
+   - `autoConnect: false` prevents auto-connecting to IDEs on startup
+   - `openDiffOnEdit: false` shows file diffs in terminal only, not in IDE
 
-4. Test the difference: with `open_diff_on_edit: true`, ask Copilot to edit a file and observe the diff opening in VS Code.
+4. Test the difference: with `openDiffOnEdit: true`, ask Copilot to edit a file and observe the diff opening in VS Code.
 
 **Expected Outcome:**
 You understand how Copilot integrates with IDEs and can customize the behavior.
@@ -316,7 +310,7 @@ You understand how Copilot integrates with IDEs and can customize the behavior.
    Or via config:
 
    ```json
-   { "streamer_mode": true }
+   { "streamerMode": true }
    ```
 
 2. Enable screen reader optimizations:
@@ -367,12 +361,12 @@ You can configure Copilot for streaming, screen readers, and plain-text environm
    ```json
    {
      "model": "gpt-4.1",
-     "include_coauthor": true,
-     "compact_paste": true,
-     "update_terminal_title": true,
+     "includeCoauthor": true,
+     "compactPaste": true,
+     "updateTerminalTitle": true,
      "beep": true,
-     "custom_agents": {
-       "default_local_only": false
+     "customAgents": {
+       "defaultLocalOnly": false
      }
    }
    ```
@@ -429,12 +423,12 @@ You can enable detailed logging and understand the log directory structure.
 
 - ✅ config.json centralizes all CLI preferences
 - ✅ Config options cover model, theme, streaming, mouse, and more
-- ✅ `compact_paste` auto-collapses large pastes into compact tokens
-- ✅ `copy_on_select` enables clipboard integration in alt-screen
+- ✅ `compactPaste` auto-collapses large pastes into compact tokens
+- ✅ `copyOnSelect` enables clipboard integration
 - ✅ `companyAnnouncements` broadcasts team messages on startup
-- ✅ `include_coauthor` auto-adds Co-authored-by to commits
-- ✅ `update_terminal_title` shows current intent in terminal title
-- ✅ IDE integration is controlled via `ide.auto_connect` and `ide.open_diff_on_edit`
+- ✅ `includeCoauthor` auto-adds Co-authored-by to commits
+- ✅ `updateTerminalTitle` shows current intent in terminal title
+- ✅ IDE integration is controlled via `ide.autoConnect` and `ide.openDiffOnEdit`
 - ✅ `/ide` connects to IDE workspaces, `/streamer-mode` hides sensitive info
 - ✅ `/copy` copies last response to clipboard
 - ✅ Environment variables control auth, model, editor, and instruction paths

--- a/triage.md
+++ b/triage.md
@@ -1,7 +1,7 @@
 # Workshop FEEDBACK Triage
 
 > Auto-generated from all `⚠️ **FEEDBACK**` callouts across workshop modules.
-> Workshop version: **v1.0.2**
+> Workshop version: **v1.0.16**
 
 ### How to use this file
 - Set **Status** to one of: `pending` · `fix` · `skip` · `done`


### PR DESCRIPTION
## Workshop Upgrade: v1.0.7 → v1.0.16

**24 files changed** | 277 insertions | 237 deletions | 9 releases covered

### Breaking Changes Applied
- Removed `--alt-screen` flag and `alt_screen` setting (removed in v1.0.12)
- Removed `gemini-3-pro-preview` model (removed in v1.0.13)
- Updated `postToolUse` semantics — fires only on success; added `postToolUseFailure`
- Added `PermissionRequest` hook for programmatic tool approval
- Updated `/clear` vs `/new` session semantics
- Migrated all config keys from `snake_case` to `camelCase`
- Updated `marketplaces` → `extraKnownMarketplaces`

### New Features Documented
- `/undo`, `/rewind`, `/new`, `/share html`, `/mcp auth`, `/allow-all` subcommands
- `--effort` shorthand, `~/.agents/skills/`, monorepo discovery
- MCP device code flow, MCP timeline display, MCP sampling

### Cleanup
- Removed 11 stale `⚠️ FEEDBACK` + `v1.0.x` warnings (now baseline)
- Removed stale `Version` columns from reference tables
- Fixed broken cross-reference: `08-plugins.md` → `07-plugins.md`
- Synced all slide decks with workshop module changes
- Updated version stamps across all metadata files